### PR TITLE
add URL to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,3 +53,4 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.0.1.9000
+URL: https://github.com/IndrajeetPatil/ggstatsplot


### PR DESCRIPTION
Having the URL here makes it easier to navigate from CRAN page to the github page.