### PR TITLE
Suggested improvement to Histograms (grouped and non grouped)

### DIFF
--- a/R/combine_plots.R
+++ b/R/combine_plots.R
@@ -1,4 +1,3 @@
-#'
 #' @title Combining multiple plots using `cowplot::plot_grid()` with a
 #'   combination of title, caption, and annotation label
 #' @name combine_plots
@@ -65,10 +64,10 @@
 #' \url{https://cran.r-project.org/package=ggstatsplot/vignettes/combine_plots.html}
 #'
 #' @examples
-#' 
+#'
 #' # loading the necessary libraries
 #' library(ggplot2)
-#' 
+#'
 #' # preparing the first plot
 #' p1 <-
 #'   ggplot2::ggplot(
@@ -77,7 +76,7 @@
 #'   ) +
 #'   geom_point() +
 #'   labs(title = "setosa")
-#' 
+#'
 #' # preparing the second plot
 #' p2 <-
 #'   ggplot2::ggplot(
@@ -86,7 +85,7 @@
 #'   ) +
 #'   geom_point() +
 #'   labs(title = "versicolor")
-#' 
+#'
 #' # combining the plot with a title and a caption
 #' combine_plots(
 #'   p1,

--- a/R/data.R
+++ b/R/data.R
@@ -1,4 +1,3 @@
-#'
 #' @title Movie information and user ratings from IMDB.com (wide format).
 #' @name movies_wide
 #' @details Modified dataset from `ggplot2movies` package.
@@ -34,8 +33,6 @@
 #' head(movies_wide)
 "movies_wide"
 
-
-#'
 #' @title Movie information and user ratings from IMDB.com (long format).
 #' @name movies_long
 #' @details Modified dataset from `ggplot2movies` package.
@@ -94,8 +91,6 @@
 #' head(Titanic_full)
 "Titanic_full"
 
-
-#'
 #' @title Moral judgments about third-party moral behavior.
 #' @name intent_morality
 #' @details This dataset contains data from a recent study about how people

--- a/R/ggcoefstats.R
+++ b/R/ggcoefstats.R
@@ -1,4 +1,3 @@
-#'
 #' @title Model coefficients for fitted models with the model summary as a
 #'   caption.
 #' @name ggcoefstats
@@ -126,7 +125,7 @@
 #' \url{https://cran.r-project.org/package=ggstatsplot/vignettes/ggcoefstats.html}
 #'
 #' @examples
-#' 
+#'
 #' set.seed(123)
 #' ggcoefstats(x = lm(formula = mpg ~ cyl * am, data = mtcars))
 #' @export

--- a/R/ggcorrmat.R
+++ b/R/ggcorrmat.R
@@ -1,4 +1,3 @@
-#'
 #' @title Visualization of a correlalogram (or correlation matrix)
 #' @name ggcorrmat
 #' @aliases ggcorrmat
@@ -125,7 +124,7 @@
 #' \url{https://cran.r-project.org/package=ggstatsplot/vignettes/ggcorrmat.html}
 #'
 #' @examples
-#' 
+#'
 #' # to get the correlalogram
 #' # note that the function will run even if the vector with variable names is
 #' # not of same length as the number of variables
@@ -134,14 +133,14 @@
 #'   cor.vars = sleep_total:bodywt,
 #'   cor.vars.names = c("total sleep", "REM sleep")
 #' )
-#' 
+#'
 #' # to get the correlation matrix
 #' ggstatsplot::ggcorrmat(
 #'   data = ggplot2::msleep,
 #'   cor.vars = sleep_total:bodywt,
 #'   output = "r"
 #' )
-#' 
+#'
 #' # setting output = "p-values" (or "p") will return the p-value matrix
 #' ggstatsplot::ggcorrmat(
 #'   data = ggplot2::msleep,
@@ -150,7 +149,7 @@
 #'   p.adjust.method = "fdr",
 #'   output = "p"
 #' )
-#' 
+#'
 #' # setting output = "ci" will return the confidence intervals for unique
 #' # correlation pairs
 #' ggstatsplot::ggcorrmat(
@@ -158,7 +157,7 @@
 #'   cor.vars = sleep_total:bodywt,
 #'   output = "ci"
 #' )
-#' 
+#'
 #' # modifying few elements of the correlation matrix by changing function defaults
 #' ggstatsplot::ggcorrmat(
 #'   data = datasets::iris,

--- a/R/gghistostats.R
+++ b/R/gghistostats.R
@@ -189,6 +189,12 @@ gghistostats <-
     data %<>%
       tibble::as_data_frame(x = .)
 
+    # Adding some binwidth sanity checking
+        if (is.null(binwidth)) {
+          binwidth <- (max(data$x) - min(data$x))/sqrt(length(data$x))
+        }
+
+
     # ========================================== stats ==================================================================
 
     if (isTRUE(results.subtitle)) {
@@ -232,10 +238,6 @@ gghistostats <-
       )
     }
     # ========================================== plot ===================================================================
-    # Adding some binwidth sanity checking
-    if (is.null(binwidth)) {
-      binwidth <- round((max(data$x) - min(data$x))/sqrt(length(data$x)))
-    }
 
     # preparing the basic layout of the plot based on whether counts or density information is needed
 

--- a/R/gghistostats.R
+++ b/R/gghistostats.R
@@ -1,4 +1,3 @@
-#'
 #' @title Histogram for distribution of a numeric variable
 #' @name gghistostats
 #' @aliases gghistostats
@@ -233,6 +232,10 @@ gghistostats <-
       )
     }
     # ========================================== plot ===================================================================
+    # Adding some binwidth sanity checking
+    if (is.null(binwidth)) {
+      binwidth <- round((max(data$x) - min(data$x))/sqrt(length(data$x)))
+    }
 
     # preparing the basic layout of the plot based on whether counts or density information is needed
 

--- a/R/ggpiestats.R
+++ b/R/ggpiestats.R
@@ -1,4 +1,3 @@
-#'
 #' @title Pie charts with statistical tests
 #' @name ggpiestats
 #' @aliases ggpiestats

--- a/R/ggscatterstats.R
+++ b/R/ggscatterstats.R
@@ -1,4 +1,3 @@
-#'
 #' @title Scatterplot with marginal distributions
 #' @name ggscatterstats
 #' @aliases ggscatterstats

--- a/R/grouped_ggbetweenstats.R
+++ b/R/grouped_ggbetweenstats.R
@@ -1,4 +1,3 @@
-#'
 #' @title Violin plots for group or condition comparisons in between-subjects
 #'   designs repeated across all levels of a grouping variable.
 #' @name grouped_ggbetweenstats

--- a/R/grouped_ggcorrmat.R
+++ b/R/grouped_ggcorrmat.R
@@ -1,4 +1,3 @@
-#'
 #' @title Visualization of a correlalogram (or correlation matrix) for all
 #'   levels of a grouping variable
 #' @name grouped_ggcorrmat
@@ -38,7 +37,7 @@
 #'
 #'
 #' @examples
-#' 
+#'
 #' # for getting plot
 #' ggstatsplot::grouped_ggcorrmat(
 #'   data = ggplot2::msleep,
@@ -49,7 +48,7 @@
 #'   nrow = 2,
 #'   ncol = 2
 #' )
-#' 
+#'
 #' # for getting correlations
 #' ggstatsplot::grouped_ggcorrmat(
 #'   data = ggplot2::msleep,
@@ -57,7 +56,7 @@
 #'   cor.vars = sleep_total:bodywt,
 #'   output = "correlations"
 #' )
-#' 
+#'
 #' # for getting confidence intervals
 #' # if robust correlation is selected, confidence intervals will not be
 #' # available

--- a/R/grouped_gghistostats.R
+++ b/R/grouped_gghistostats.R
@@ -87,7 +87,6 @@ grouped_gghistostats <- function(data,
                                  messages = TRUE,
                                  ...) {
   # ================== preparing dataframe ==================
-#  return(data$x)
   # getting the dataframe ready
   df <- dplyr::select(
     .data = data,
@@ -99,22 +98,21 @@ grouped_gghistostats <- function(data,
       title.text = !!rlang::enquo(grouping.var)
     )
 
-  xxx <- dplyr::select(
+  binmax <- dplyr::select(
     .data = data,
     !!rlang::enquo(x)
   ) %>% max
 
-  yyy <- dplyr::select(
+  binmin <- dplyr::select(
     .data = data,
     !!rlang::enquo(x)
   ) %>% min
 
-  zzz <- as.integer(data %>% dplyr::count())
+  bincount <- as.integer(data %>% dplyr::count())
 
   # Adding some binwidth sanity checking
   if (is.null(binwidth)) {
-    binwidth <- (xxx - yyy)/sqrt(zzz)
-#    return((xxx - yyy)/sqrt(zzz))
+    binwidth <- (binmax - binmin)/sqrt(bincount)
   }
 
 
@@ -175,7 +173,6 @@ grouped_gghistostats <- function(data,
             test.line.labeller = test.line.labeller,
             test.k = test.k,
             binwidth = binwidth,
-#            binwidth = 0.2939388,
             ggtheme = ggtheme,
             ggstatsplot.layer = ggstatsplot.layer,
             fill.gradient = fill.gradient,
@@ -193,5 +190,4 @@ grouped_gghistostats <- function(data,
 
   # return the combined plot
   return(combined_plot)
-#  return(df)
 }

--- a/R/grouped_gghistostats.R
+++ b/R/grouped_gghistostats.R
@@ -87,7 +87,7 @@ grouped_gghistostats <- function(data,
                                  messages = TRUE,
                                  ...) {
   # ================== preparing dataframe ==================
-
+#  return(data$x)
   # getting the dataframe ready
   df <- dplyr::select(
     .data = data,
@@ -98,6 +98,25 @@ grouped_gghistostats <- function(data,
       .data = .,
       title.text = !!rlang::enquo(grouping.var)
     )
+
+  xxx <- dplyr::select(
+    .data = data,
+    !!rlang::enquo(x)
+  ) %>% max
+
+  yyy <- dplyr::select(
+    .data = data,
+    !!rlang::enquo(x)
+  ) %>% min
+
+  zzz <- as.integer(data %>% dplyr::count())
+
+  # Adding some binwidth sanity checking
+  if (is.null(binwidth)) {
+    binwidth <- (xxx - yyy)/sqrt(zzz)
+#    return((xxx - yyy)/sqrt(zzz))
+  }
+
 
   # creating a nested dataframe
   df %<>%
@@ -156,6 +175,7 @@ grouped_gghistostats <- function(data,
             test.line.labeller = test.line.labeller,
             test.k = test.k,
             binwidth = binwidth,
+#            binwidth = 0.2939388,
             ggtheme = ggtheme,
             ggstatsplot.layer = ggstatsplot.layer,
             fill.gradient = fill.gradient,
@@ -173,4 +193,5 @@ grouped_gghistostats <- function(data,
 
   # return the combined plot
   return(combined_plot)
+#  return(df)
 }

--- a/R/grouped_gghistostats.R
+++ b/R/grouped_gghistostats.R
@@ -1,4 +1,3 @@
-#'
 #' @title Grouped histograms for distribution of a numeric variable
 #' @name grouped_gghistostats
 #' @aliases grouped_gghistostats

--- a/R/grouped_ggscatterstats.R
+++ b/R/grouped_ggscatterstats.R
@@ -1,4 +1,3 @@
-#'
 #' @title Scatterplot with marginal distributions for all levels of a grouping
 #'   variable
 #' @name grouped_ggscatterstats
@@ -36,10 +35,10 @@
 #' @inherit ggscatterstats return details
 #'
 #' @examples
-#' 
+#'
 #' # to ensure reproducibility
 #' set.seed(123)
-#' 
+#'
 #' # basic function call
 #' ggstatsplot::grouped_ggscatterstats(
 #'   data = dplyr::filter(
@@ -53,7 +52,7 @@
 #'   formula = y ~ x + I(x^3),
 #'   grouping.var = genre
 #' )
-#' 
+#'
 #' # using labeling
 #' ggstatsplot::grouped_ggscatterstats(
 #'   data = dplyr::filter(ggplot2::mpg, cyl != 5),
@@ -66,7 +65,7 @@
 #'   label.expression = hwy > 25 & displ > 2.5,
 #'   messages = FALSE
 #' )
-#' 
+#'
 #' # labeling without expression
 #' ggstatsplot::grouped_ggscatterstats(
 #'   data = dplyr::filter(

--- a/R/helpers_effsize_ci.R
+++ b/R/helpers_effsize_ci.R
@@ -1,4 +1,3 @@
-#'
 #' @title A heteroscedastic one-way ANOVA for trimmed means with confidence
 #'   interval for effect size.
 #' @name t1way_ci
@@ -469,7 +468,6 @@ chisq_v_ci <- function(data,
 }
 
 
-#'
 #' @title Robust correlation coefficient and its confidence interval
 #' @name robcor_ci
 #' @description Custom function to get confidence intervals for percentage bend
@@ -620,7 +618,6 @@ robcor_ci <- function(data,
   return(results_df)
 }
 
-#'
 #' @title Confidence intervals for partial eta-squared and omega-squared for
 #'   linear models.
 #' @name lm_effsize_ci

--- a/R/theme_ggstatsplot.R
+++ b/R/theme_ggstatsplot.R
@@ -1,4 +1,3 @@
-#'
 #' @title Default theme used in all `ggstatsplot` package plots
 #' @name theme_ggstatsplot
 #' @author Indrajeet Patil
@@ -68,7 +67,6 @@ theme_ggstatsplot <- function(ggtheme = ggplot2::theme_bw(), ggstatsplot.layer =
   }
 }
 
-#'
 #' @title Default theme used in all `ggstatsplot` package plots
 #' @name theme_mprl
 #' @author Indrajeet Patil


### PR DESCRIPTION
Hi,

While I applaud and appreciate Hadley's decision within ggplot2 to not automatically assign a number of bins in a histogram I do not believe that's the right decision for ggstatsplot where we're making some rational choices for the end user.  It generates a warning message that many won't initially understand and clutters things up.

This fix provides a rational default value for bins if the user leaves it NULL. No impact if they specify something. The default is a common choice:

`binwidth <- (max(data$x) - min(data$x))/sqrt(length(data$x))`

I also removed some comment lines since at least in the build process for me it generates annoying warnings.  They are completely non substantive.

Thanks for considering.

Chuck
