### PR TITLE
Removing roxygen warning messages from the following files:

### DIFF
--- a/R/grouped_ggpiestats.R
+++ b/R/grouped_ggpiestats.R
@@ -1,4 +1,3 @@
-#'
 #' @title Grouped pie charts with statistical tests
 #' @name grouped_ggpiestats
 #' @aliases grouped_ggpiestats
@@ -35,17 +34,17 @@
 #' @inherit ggpiestats return details
 #'
 #' @examples
-#' 
+#'
 #' # grouped one-sample proportion tests
 #' ggstatsplot::grouped_ggpiestats(
 #'   data = mtcars,
 #'   grouping.var = am,
 #'   main = cyl
 #' )
-#' 
+#'
 #' #' without condition and with count data
 #' library(jmv)
-#' 
+#'
 #' ggstatsplot::grouped_ggpiestats(
 #'   data = as.data.frame(HairEyeColor),
 #'   main = Hair,

--- a/R/helpers_ggbetween_subtitles.R
+++ b/R/helpers_ggbetween_subtitles.R
@@ -242,7 +242,6 @@ subtitle_ggbetween_anova_parametric <-
   }
 
 
-#'
 #' @title Making text subtitle for the t-test (between-/within-subjects designs).
 #' @name subtitle_ggbetween_t_parametric
 #' @author Indrajeet Patil
@@ -408,7 +407,6 @@ subtitle_ggbetween_t_parametric <-
   }
 
 
-#'
 #' @title Making text subtitle for the Mann-Whitney U-test
 #'   (between-/within-subjects designs).
 #' @name subtitle_ggbetween_mann_nonparametric
@@ -511,7 +509,6 @@ subtitle_ggbetween_mann_nonparametric <-
     return(subtitle)
   }
 
-#'
 #' @title Making text subtitle for the robust t-test
 #'   (between-subjects designs).
 #' @name subtitle_ggbetween_t_rob
@@ -630,7 +627,6 @@ subtitle_ggbetween_t_rob <-
     return(subtitle)
   }
 
-#'
 #' @title Making text subtitle for the bayesian t-test.
 #' @name subtitle_ggbetween_t_bayes
 #' @author Indrajeet Patil
@@ -643,18 +639,18 @@ subtitle_ggbetween_t_rob <-
 #' @importFrom jmv ttestPS
 #'
 #' @examples
-#' 
+#'
 #' # between-subjects design
-#' 
+#'
 #' subtitle_ggbetween_t_bayes(
 #'   data = mtcars,
 #'   x = am,
 #'   y = wt,
 #'   paired = FALSE
 #' )
-#' 
+#'
 #' # within-subjects design
-#' 
+#'
 #' subtitle_ggbetween_t_bayes(
 #'   data = dplyr::filter(
 #'     ggstatsplot::intent_morality,
@@ -782,7 +778,6 @@ subtitle_ggbetween_t_bayes <- function(data,
 }
 
 
-#'
 #' @title Making text subtitle for the Kruskal-Wallis test (nonparametric ANOVA)
 #'   (between-subjects designs).
 #' @name subtitle_ggbetween_kw_nonparametric
@@ -874,7 +869,6 @@ subtitle_ggbetween_kw_nonparametric <-
     return(subtitle)
   }
 
-#'
 #' @title Making text subtitle for the robust ANOVA
 #'   (between-subjects designs).
 #' @name subtitle_ggbetween_rob_anova

--- a/R/helpers_gghistostats_subtitles.R
+++ b/R/helpers_gghistostats_subtitles.R
@@ -1,5 +1,3 @@
-
-#'
 #' @title Making text subtitle for one sample t-test and its nonparametric and
 #'   robust equivalents.
 #' @name subtitle_onesample
@@ -42,7 +40,7 @@
 #' @importFrom psych cohen.d.ci
 #'
 #' @examples
-#' 
+#'
 #' subtitle_onesample(x = iris$Sepal.Length, type = "r")
 #' @export
 #'

--- a/R/helpers_ggpiestats_subtitles.R
+++ b/R/helpers_ggpiestats_subtitles.R
@@ -1,4 +1,3 @@
-#'
 #' @title Making text subtitle for contingency analysis (Pearson's chi-square
 #'   test for independence for between-subjects design or McNemar's test for
 #'   within-subjects design)
@@ -28,21 +27,21 @@
 #' @importFrom exact2x2 exact2x2
 #'
 #' @examples
-#' 
+#'
 #' # without counts data
 #' subtitle_contigency_tab(
 #'   data = mtcars,
 #'   main = am,
 #'   condition = cyl
 #' )
-#' 
+#'
 #' # with counts data
 #' # in case of no variation, NaN will be shown for results
 #' library(jmv)
-#' 
+#'
 #' dat <- as.data.frame(HairEyeColor) %>%
 #'   dplyr::filter(.data = ., Sex == "Male")
-#' 
+#'
 #' subtitle_contigency_tab(
 #'   data = dat,
 #'   main = Hair,
@@ -271,7 +270,6 @@ subtitle_contigency_tab <- function(data,
 }
 
 
-#'
 #' @title Making text subtitle for Proportion Test (N Outcomes), a chi-squared
 #'   Goodness of fit test.
 #' @name subtitle_onesample_proptest
@@ -285,16 +283,16 @@ subtitle_contigency_tab <- function(data,
 #' @inheritParams subtitle_contigency_tab
 #'
 #' @examples
-#' 
+#'
 #' # with counts
 #' library(jmv)
-#' 
+#'
 #' subtitle_onesample_proptest(
 #'   data = as.data.frame(HairEyeColor),
 #'   main = Eye,
 #'   counts = Freq
 #' )
-#' 
+#'
 #' # in case no variation, only sample size will be shown
 #' subtitle_onesample_proptest(
 #'   data = cbind.data.frame(x = rep("a", 10)),

--- a/R/helpers_ggscatterstats_subtitles.R
+++ b/R/helpers_ggscatterstats_subtitles.R
@@ -1,4 +1,3 @@
-#'
 #' @title Making text subtitle for the correlation test.
 #' @name subtitle_ggscatterstats
 #' @author Indrajeet Patil

--- a/R/helpers_messages.R
+++ b/R/helpers_messages.R
@@ -1,4 +1,3 @@
-#'
 #' @title Display normality test result as a message.
 #' @name normality_message
 #' @aliases normality_message
@@ -22,10 +21,10 @@
 #' @family helper_messages
 #'
 #' @examples
-#' 
+#'
 #' # message
 #' normality_message(x = datasets::anscombe$x1, lab = "x1")
-#' 
+#'
 #' # statistical test object
 #' normality_message(
 #'   x = datasets::anscombe$x2,
@@ -74,7 +73,6 @@ normality_message <- function(x, lab = NULL, k = 3, output = "message") {
 }
 
 
-#'
 #' @title Display homogeneity of variance test as a message
 #' @name bartlett_message
 #' @aliases bartlett_message
@@ -98,7 +96,7 @@ normality_message <- function(x, lab = NULL, k = 3, output = "message") {
 #' @family helper_messages
 #'
 #' @examples
-#' 
+#'
 #' # getting message
 #' bartlett_message(
 #'   data = iris,
@@ -106,7 +104,7 @@ normality_message <- function(x, lab = NULL, k = 3, output = "message") {
 #'   y = Sepal.Length,
 #'   lab = "Type of Species"
 #' )
-#' 
+#'
 #' # getting results from the test
 #' bartlett_message(
 #'   data = mtcars,

--- a/R/helpers_stats.R
+++ b/R/helpers_stats.R
@@ -1,4 +1,3 @@
-#'
 #' @title Function to run proportion test on grouped data.
 #' @name grouped_proptest
 #' @aliases grouped_proptest
@@ -182,10 +181,10 @@ grouped_proptest <- function(data,
 #' @family helper_stats
 #'
 #' @examples
-#' 
+#'
 #' # vector as input
 #' signif_column(p = c(0.05, 0.1, 1, 0.00001, 0.001, 0.01))
-#' 
+#'
 #' # dataframe as input
 #' # preparing a newdataframe
 #' df <- tibble(
@@ -193,9 +192,9 @@ grouped_proptest <- function(data,
 #'   y = 1,
 #'   p.value = c(0.1, 0.5, 0.00001, 0.05, 0.01)
 #' )
-#' 
+#'
 #' signif_column(data = df, p = p.value)
-#' 
+#'
 #' # numbers entered as characters are also tolerated
 #' signif_column(p = c("1", "0.1", "0.0002", "0.03", "0.65"))
 #' @export
@@ -336,7 +335,7 @@ check_outlier <- function(var, coef = 1.5) {
 #' @family helper_stats
 #'
 #' @examples
-#' 
+#'
 #' # have a look at the Titanic_full dataset first
 #' Titanic_full <- untable(data = as.data.frame(Titanic), counts = Freq)
 #' dplyr::glimpse(Titanic_full)

--- a/R/specify_decimal_p.R
+++ b/R/specify_decimal_p.R
@@ -1,4 +1,3 @@
-#'
 #' @title Custom function for getting specified number of decimal places in
 #'   results for p-value
 #' @name specify_decimal_p

--- a/R/theme_ggstatsplot.R
+++ b/R/theme_ggstatsplot.R
@@ -85,7 +85,6 @@ theme_ggstatsplot <- function(ggtheme = ggplot2::theme_bw(), ggstatsplot.layer =
 
 theme_mprl <- theme_ggstatsplot
 
-#'
 #' @title Default theme used for pie chart
 #' @name theme_pie
 #' @author Indrajeet Patil
@@ -163,7 +162,6 @@ theme_pie <- function(ggtheme = ggplot2::theme_bw(),
 }
 
 
-#'
 #' @title Default theme used for correlation matrix
 #' @name theme_corrmat
 #' @author Indrajeet Patil


### PR DESCRIPTION
Per our discussion I'll try and keep these modular and bundled.  These are all cosmetic changes.

@details [grouped_ggpiestats.R#1]: requires a value
@description helpers_ggbetween_subtitles.R#1]: requires a value
@description helpers_ggbetween_subtitles.R#1]: requires a value
@description helpers_ggbetween_subtitles.R#1]: requires a value
@description helpers_ggbetween_subtitles.R#1]: requires a value
@description helpers_ggbetween_subtitles.R#1]: requires a value
@description helpers_ggbetween_subtitles.R#1]: requires a value
@description helpers_gghistostats_subtitles.R#1]: requires a value
@description helpers_ggpiestats_subtitles.R#1]: requires a value
@description helpers_ggpiestats_subtitles.R#1]: requires a value
@description helpers_ggscatterstats_subtitles.R#1]: requires a value
@details helpers_messages.R#1]: requires a value
@inherit helpers_messages.R#21]: Unknown inherit type: value
@details helpers_messages.R#1]: requires a value
@inherit helpers_messages.R#97]: Unknown inherit type: value
@description helpers_stats.R#1]: requires a value
@details specify_decimal_p.R#1]: requires a value
@description theme_ggstatsplot.R#1]: requires a value
@description theme_ggstatsplot.R#1]: requires a value