### PR TITLE
Bug fix for #84 …

### DIFF
--- a/R/grouped_ggbetweenstats.R
+++ b/R/grouped_ggbetweenstats.R
@@ -33,10 +33,10 @@
 #' @inherit ggbetweenstats return details
 #'
 #' @examples
-#' 
+#'
 #' # to get reproducible results from bootstrapping
 #' set.seed(123)
-#' 
+#'
 #' # the most basic function call
 #' ggstatsplot::grouped_ggbetweenstats(
 #'   data = dplyr::filter(ggplot2::mpg, drv != "4"),
@@ -98,6 +98,8 @@ grouped_ggbetweenstats <- function(data,
                                    messages = TRUE,
                                    ...) {
   # ======================== preparing dataframe ==========================
+  # ensure the grouping variable works quoted or unquoted
+  grouping.var <- rlang::ensym(grouping.var)
 
   if (!base::missing(outlier.label)) {
     df <-


### PR DESCRIPTION
work irrespective of whether you enter a character (grouping.var = "x") or or a bare expression (grouping.var = x). But this doesn't seem to be working for grouped_ variants of functions for the grouping.var argument?