### PR TITLE
fix for issue #103

### DIFF
--- a/R/grouped_ggbetweenstats.R
+++ b/R/grouped_ggbetweenstats.R
@@ -27,10 +27,10 @@
 #' @inherit ggbetweenstats return details
 #'
 #' @examples
-#' 
+#'
 #' # to get reproducible results from bootstrapping
 #' set.seed(123)
-#' 
+#'
 #' # the most basic function call
 #' ggstatsplot::grouped_ggbetweenstats(
 #'   data = dplyr::filter(ggplot2::mpg, drv != "4"),
@@ -96,11 +96,16 @@ grouped_ggbetweenstats <- function(data,
                                    direction = 1,
                                    messages = TRUE,
                                    ...) {
-  # ======================== preparing dataframe ==========================
+
+  # ======================== check user input =============================
+
+  # create a list of function call to check
+  param_list <- base::as.list(base::match.call())
   # ensure the grouping variable works quoted or unquoted
   grouping.var <- rlang::ensym(grouping.var)
 
-  if (!base::missing(outlier.label)) {
+  # ======================== preparing dataframe ==========================
+  if (!base::missing(outlier.label) && "outlier.tagging" %in% names(param_list)) {
     df <-
       dplyr::select(
         .data = data,
@@ -147,7 +152,7 @@ grouped_ggbetweenstats <- function(data,
     tidyr::nest(data = .)
 
   # creating a list of plots
-  if (!base::missing(outlier.label)) {
+  if (!base::missing(outlier.label) && "outlier.tagging" %in% names(param_list)) {
     plotlist_purrr <-
       df %>%
       dplyr::mutate(


### PR DESCRIPTION
#103  Tests for the presence of both outlier tagging and outlier label and only reduces sample size when both are true/present.

I'll look at refactoring separately

``` r
set.seed(123)
library(ggplot2)
library(ggstatsplot)

# create a dataset
df <- ggplot2::msleep
df$group <- "1"

# bare function
ggbetweenstats(df,
               vore,
               brainwt,
               messages = FALSE,
               outlier.label = conservation)
```

![](https://i.imgur.com/tobJZMa.png)

``` r

# grouped function
grouped_ggbetweenstats(
  df,
  vore,
  brainwt,
  grouping.var = group,
  outlier.label = conservation,
  messages = FALSE
)
```

![](https://i.imgur.com/givVXa6.png)

``` r

# grouped function tagging on
grouped_ggbetweenstats(
  df,
  vore,
  brainwt,
  grouping.var = group,
  outlier.label = conservation,
  outlier.tagging = TRUE,
  messages = FALSE
)
```

![](https://i.imgur.com/OnnpixG.png)

<sup>Created on 2019-01-03 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>