### PR TITLE
More on Issue #103

### DIFF
--- a/R/ggbetweenstats.R
+++ b/R/ggbetweenstats.R
@@ -147,10 +147,10 @@
 #' \url{https://indrajeetpatil.github.io/ggstatsplot/articles/web_only/ggbetweenstats.html}
 #'
 #' @examples
-#' 
+#'
 #' # to get reproducible results from bootstrapping
 #' set.seed(123)
-#' 
+#'
 #' # simple function call with the defaults
 #' ggstatsplot::ggbetweenstats(
 #'   data = mtcars,
@@ -160,7 +160,7 @@
 #'   caption = "Transmission (0 = automatic, 1 = manual)",
 #'   bf.message = TRUE
 #' )
-#' 
+#'
 #' # more detailed function call
 #' ggstatsplot::ggbetweenstats(
 #'   data = datasets::morley,
@@ -523,8 +523,9 @@ ggbetweenstats <- function(data,
         )
       ) %>%
       dplyr::ungroup(x = .) %>%
-      stats::na.omit(.) %>%
+      dplyr::filter(.data = ., isanoutlier) %>%
       dplyr::select(.data = ., -outlier)
+      data_outlier_label$outlier.label <- stringr::str_replace_na(string = data_outlier_label$outlier.label, replacement = "NA")
 
     # applying the labels to tagged outliers with ggrepel
     plot <-

--- a/R/grouped_ggbetweenstats.R
+++ b/R/grouped_ggbetweenstats.R
@@ -122,7 +122,8 @@ grouped_ggbetweenstats <- function(data,
         .data = .,
         title.text = !!rlang::enquo(grouping.var)
       ) %>%
-      stats::na.omit(.)
+#      stats::na.omit(.)
+      dplyr::filter(.data = ., !is.na(!!rlang::enquo(x)), !is.na(!!rlang::enquo(y)), !is.na(!!rlang::enquo(grouping.var)))
   } else {
     df <-
       dplyr::select(


### PR DESCRIPTION
Ensure that outliers are labelled with the string "NA" if the  #underlying outlier.label is NA.  After the last PR it was possible to have obvious outliers which didn't get label's because for example in omnivore there was one value that was missing.

No changes to testing or doco.  there's one line of code that is very long you may want to condense to more your style.

``` r
set.seed(123)
library(ggplot2)
library(ggstatsplot)

# create a dataset
df <- ggplot2::msleep
df$group <- "1"

grouped_ggbetweenstats(
  df,
  "vore",
  "brainwt",
  grouping.var = group,
  outlier.tagging = TRUE,
  messages = FALSE
)
```

![](https://i.imgur.com/HEQpX0H.png)

``` r

grouped_ggbetweenstats(
  df,
  "vore",
  "brainwt",
  grouping.var = group,
  outlier.label = conservation, 
  outlier.tagging = TRUE,
  messages = FALSE
)
```

![](https://i.imgur.com/pvIhlly.png)

<sup>Created on 2019-01-03 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>