### PR TITLE
Issue116 fix

### DIFF
--- a/R/ggscatterstats.R
+++ b/R/ggscatterstats.R
@@ -98,15 +98,15 @@
 #' }
 #'
 #' @examples
-#' 
+#'
 #' # to get reproducible results from bootstrapping
 #' set.seed(123)
-#' 
+#'
 #' # creating dataframe
 #' mtcars_new <- mtcars %>%
 #'   tibble::rownames_to_column(., var = "car") %>%
 #'   tibble::as_tibble(x = .)
-#' 
+#'
 #' # simple function call with the defaults
 #' ggstatsplot::ggscatterstats(
 #'   data = mtcars_new,
@@ -287,6 +287,9 @@ ggscatterstats <- function(data,
   }
 
   #--------------------------------- basic plot ---------------------------
+  pos <- position_jitter(width = point.width.jitter,
+                         height = point.height.jitter,
+                         seed = 123)
 
   # if user has not specified colors, then use a color palette
   if (is.null(xfill) || is.null(yfill)) {
@@ -317,10 +320,7 @@ ggscatterstats <- function(data,
       size = point.size,
       alpha = point.alpha,
       stroke = 0,
-      position = ggplot2::position_jitter(
-        width = point.width.jitter,
-        height = point.height.jitter
-      ),
+      position = pos,
       na.rm = TRUE
     ) +
     ggplot2::geom_smooth(
@@ -514,7 +514,7 @@ ggscatterstats <- function(data,
         point.padding = 0.5,
         segment.color = "black",
         force = 2,
-        seed = 123,
+        position = pos,
         na.rm = TRUE
       )
   }

--- a/tests/testthat/test_ggscatterstats.R
+++ b/tests/testthat/test_ggscatterstats.R
@@ -222,12 +222,12 @@ testthat::test_that(
 
     # checking intercepts
     testthat::expect_equal(pb$plot$plot_env$x_label_pos,
-      0.8066451,
+      0.811,
       tolerance = 1e-3
     )
     testthat::expect_equal(pb$plot$plot_env$y_label_pos,
-      13.37923,
-      tolerance = 1e-3
+      13.4,
+      tolerance = 1e-1
     )
     testthat::expect_equal(pb$data[[3]]$xintercept[[1]],
       median(ggplot2::msleep$sleep_cycle, na.rm = TRUE),
@@ -240,8 +240,8 @@ testthat::test_that(
 
     # checking panel parameters
     testthat::expect_equal(pb$layout$panel_params[[1]]$x.range,
-      c(0.0405715, 1.5722818),
-      tolerance = 0.001
+      c(0.0472, 1.5748),
+      tolerance = 0.01
     )
     testthat::expect_identical(
       pb$layout$panel_params[[1]]$x.labels,


### PR DESCRIPTION
#116 
Some minor changes to implement [(slowkow/ggrepel#52)](https://github.com/slowkow/ggrepel/issues/52).

Had to also change the test file to account for the small difference.

I **_did NOT change_** the default for jitter although I still recommend we do I'll leave it to you.

``` r
library(ggstatsplot)
# creating a small dataframe
set.seed(123)
df <- ggstatsplot::movies_long %>%
  dplyr::filter(.data = .,
                genre %in% c("Comedy", "Drama"),
                mpaa %in% c("PG", "R")) %>%
  dplyr::sample_frac(tbl = ., size = 0.015)

# plot default is NULL which means 40%
ggstatsplot::ggscatterstats(
  data = df,
  x = "length",
  y = rating,
  label.var = title,
  results.subtitle = FALSE,
  messages = FALSE,
  marginal = FALSE
)
```

![](https://i.imgur.com/xxzHjg9.png)

``` r
# plot force to zero
ggstatsplot::ggscatterstats(
  data = df,
  x = "length",
  y = rating,
  label.var = title,
  results.subtitle = FALSE,
  messages = FALSE, , 
  point.width.jitter = 0, 
  point.height.jitter = 0,
  marginal = FALSE
)
```

![](https://i.imgur.com/ZsUijcu.png)

``` r
# plot force to 50%
ggstatsplot::ggscatterstats(
  data = df,
  x = "length",
  y = rating,
  label.var = title,
  results.subtitle = FALSE,
  messages = FALSE, , 
  point.width.jitter = .5, 
  point.height.jitter = .5,
  marginal = FALSE
)
```

![](https://i.imgur.com/LWkgQGx.png)

<sup>Created on 2019-01-03 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>