### PR TITLE
Refactor grouped_ggcorrmat

### DIFF
--- a/R/grouped_ggcorrmat.R
+++ b/R/grouped_ggcorrmat.R
@@ -130,7 +130,6 @@ grouped_ggcorrmat <- function(data,
 
   # ensure the grouping variable works quoted or unquoted
   grouping.var <- rlang::ensym(grouping.var)
-#  cor.vars <- rlang::enexpr(cor.vars)
 
   # getting the dataframe ready
   if("cor.vars" %in% names(param_list)) {
@@ -144,15 +143,14 @@ grouped_ggcorrmat <- function(data,
         .data = .,
         title.text = !!rlang::enquo(grouping.var)
       )
-#    return(df)
   } else {
     df <- data %>%
       dplyr::mutate(
         .data = .,
         title.text = !!rlang::enquo(grouping.var)
       )
-#    return(df)
   }
+
   # creating a nested dataframe
   df %<>%
     dplyr::mutate_if(
@@ -169,7 +167,7 @@ grouped_ggcorrmat <- function(data,
     dplyr::arrange(.data = ., !!rlang::enquo(grouping.var)) %>%
     dplyr::group_by(.data = ., !!rlang::enquo(grouping.var)) %>%
     tidyr::nest(data = .)
-# return(df)
+
   # ===================== grouped plot ===================================
 
   # see which method was used to specify type of correlation

--- a/R/grouped_ggcorrmat.R
+++ b/R/grouped_ggcorrmat.R
@@ -27,17 +27,17 @@
 #' @inherit ggcorrmat return details
 #'
 #' @examples
-#' 
+#'
 #' # for reproducibility
 #' set.seed(123)
-#' 
+#'
 #' # for plot
 #' # (without specifiying needed variables; all numeric variables will be used)
 #' ggstatsplot::grouped_ggcorrmat(
 #'   data = ggplot2::msleep,
 #'   grouping.var = vore
 #' )
-#' 
+#'
 #' # for getting plot
 #' ggstatsplot::grouped_ggcorrmat(
 #'   data = ggplot2::msleep,
@@ -50,7 +50,7 @@
 #'   palette = "BottleRocket2",
 #'   nrow = 2
 #' )
-#' 
+#'
 #' # for getting correlations
 #' ggstatsplot::grouped_ggcorrmat(
 #'   data = ggplot2::msleep,
@@ -58,7 +58,7 @@
 #'   cor.vars = sleep_total:bodywt,
 #'   output = "correlations"
 #' )
-#' 
+#'
 #' # for getting confidence intervals
 #' # confidence intervals are not available for **robust** correlation
 #' ggstatsplot::grouped_ggcorrmat(
@@ -130,20 +130,29 @@ grouped_ggcorrmat <- function(data,
 
   # ensure the grouping variable works quoted or unquoted
   grouping.var <- rlang::ensym(grouping.var)
+#  cor.vars <- rlang::enexpr(cor.vars)
 
   # getting the dataframe ready
-  df <-
-    dplyr::select(
-      .data = data,
-      !!rlang::enquo(grouping.var),
-      !!rlang::enquo(cor.vars),
-      dplyr::everything()
-    ) %>%
-    dplyr::mutate(
-      .data = .,
-      title.text = !!rlang::enquo(grouping.var)
-    )
-
+  if("cor.vars" %in% names(param_list)) {
+    df <-
+      dplyr::select(
+        .data = data,
+        !!rlang::enquo(grouping.var),
+        !!rlang::enquo(cor.vars)
+      ) %>%
+      dplyr::mutate(
+        .data = .,
+        title.text = !!rlang::enquo(grouping.var)
+      )
+#    return(df)
+  } else {
+    df <- data %>%
+      dplyr::mutate(
+        .data = .,
+        title.text = !!rlang::enquo(grouping.var)
+      )
+#    return(df)
+  }
   # creating a nested dataframe
   df %<>%
     dplyr::mutate_if(
@@ -160,7 +169,7 @@ grouped_ggcorrmat <- function(data,
     dplyr::arrange(.data = ., !!rlang::enquo(grouping.var)) %>%
     dplyr::group_by(.data = ., !!rlang::enquo(grouping.var)) %>%
     tidyr::nest(data = .)
-
+# return(df)
   # ===================== grouped plot ===================================
 
   # see which method was used to specify type of correlation
@@ -169,61 +178,6 @@ grouped_ggcorrmat <- function(data,
 
   # creating a list of plots
   if (output == "plot") {
-    if (!base::missing(cor.vars)) {
-      plotlist_purrr <-
-        df %>%
-        dplyr::mutate(
-          .data = .,
-          plots = data %>%
-            purrr::set_names(x = ., nm = !!rlang::enquo(grouping.var)) %>%
-            purrr::map(
-              .x = .,
-              .f = ~ ggstatsplot::ggcorrmat(
-                title = glue::glue("{title.prefix}: {as.character(.$title.text)}"),
-                data = .,
-                cor.vars = !!rlang::enquo(cor.vars),
-                cor.vars.names = cor.vars.names,
-                output = output,
-                matrix.type = matrix.type,
-                method = method,
-                corr.method = corr.method,
-                exact = exact,
-                continuity = continuity,
-                beta = beta,
-                digits = digits,
-                sig.level = sig.level,
-                p.adjust.method = p.adjust.method,
-                hc.order = hc.order,
-                hc.method = hc.method,
-                lab = lab,
-                package = package,
-                palette = palette,
-                direction = direction,
-                colors = colors,
-                outline.color = outline.color,
-                ggtheme = ggtheme,
-                ggstatsplot.layer = ggstatsplot.layer,
-                subtitle = subtitle,
-                caption = caption,
-                caption.default = caption.default,
-                lab.col = lab.col,
-                lab.size = lab.size,
-                insig = insig,
-                pch = pch,
-                pch.col = pch.col,
-                pch.cex = pch.cex,
-                tl.cex = tl.cex,
-                tl.col = tl.col,
-                tl.srt = tl.srt,
-                axis.text.x.margin.t = axis.text.x.margin.t,
-                axis.text.x.margin.r = axis.text.x.margin.r,
-                axis.text.x.margin.b = axis.text.x.margin.b,
-                axis.text.x.margin.l = axis.text.x.margin.l,
-                messages = messages
-              )
-            )
-        )
-    } else {
       plotlist_purrr <-
         df %>%
         dplyr::mutate(
@@ -276,7 +230,6 @@ grouped_ggcorrmat <- function(data,
               )
             )
         )
-    }
 
     # combining the list of plots into a single plot
     combined_plot <-


### PR DESCRIPTION
Well that was a bit of a struggle and I had to go a different way. No changes to tests or doco.

Don't know if you did it deliberately but the original line 136-140 didn't do much the end result was select everything.  Turns out the easiest thing to do was simply make it unnecessary to pass `cor.vars` through `purrr` at all.  Turns out that is hard to do.  So I make the grouped_ version do the work of reducing the dataframe and nesting it and then I don't have to pass it.

Should be good.  Turns out the non-grouped version accepts numerics 6:10 but the grouped_ version didn't before and won't now.  As the reprex shows all the other reasonable permutations work.  


``` r
library(ggplot2)
library(ggstatsplot)
# for reproducibility
set.seed(123)
ggstatsplot::grouped_ggcorrmat(
  data = ggplot2::msleep,
  grouping.var = vore
)
#> Warning: Individual plots in the combined `grouped_` plot
#> can't be further modified with `ggplot2` functions.
#> 
```

![](https://i.imgur.com/IuORnY6.png)

``` r

# for getting confidence intervals
# confidence intervals are not available for **robust** correlation
ggstatsplot::grouped_ggcorrmat(
  data = datasets::iris,
  grouping.var = Species,
  p.adjust.method = "holm",
  cor.vars = c("Sepal.Length", "Petal.Width"),
  output = "ci"
)
#> Note: In the correlation matrix,
#> the upper triangle: p-values adjusted for multiple comparisons
#> the lower triangle: unadjusted p-values.
#> 
#> Note: In the correlation matrix,
#> the upper triangle: p-values adjusted for multiple comparisons
#> the lower triangle: unadjusted p-values.
#> 
#> Note: In the correlation matrix,
#> the upper triangle: p-values adjusted for multiple comparisons
#> the lower triangle: unadjusted p-values.
#> 
#> # A tibble: 3 x 8
#>   Group      pair            r     lower upper        p lower.adj upper.adj
#>   <chr>      <chr>       <dbl>     <dbl> <dbl>    <dbl>     <dbl>     <dbl>
#> 1 setosa     Spl.L-Ptl.W 0.278 -0.000270 0.516  5.05e-2 -0.000270     0.516
#> 2 versicolor Spl.L-Ptl.W 0.546  0.316    0.716  4.04e-5  0.316        0.716
#> 3 virginica  Spl.L-Ptl.W 0.281  0.00299  0.519  4.80e-2  0.00299      0.519

ggstatsplot::grouped_ggcorrmat(
  data = datasets::iris,
  grouping.var = Species,
  p.adjust.method = "holm",
  cor.vars = "Sepal.Length":"Petal.Width"
)
#> Note: In the correlation matrix,
#> the upper triangle: p-values adjusted for multiple comparisons
#> the lower triangle: unadjusted p-values.
#> 
#> Note: In the correlation matrix,
#> the upper triangle: p-values adjusted for multiple comparisons
#> the lower triangle: unadjusted p-values.
#> 
#> Note: In the correlation matrix,
#> the upper triangle: p-values adjusted for multiple comparisons
#> the lower triangle: unadjusted p-values.
#> 
#> Warning: Individual plots in the combined `grouped_` plot
#> can't be further modified with `ggplot2` functions.
#> 
```

![](https://i.imgur.com/TRw6o2G.png)

``` r

ggstatsplot::grouped_ggcorrmat(
  data = datasets::iris,
  grouping.var = Species,
  p.adjust.method = "holm",
  cor.vars = Sepal.Length:Petal.Width
)
#> Note: In the correlation matrix,
#> the upper triangle: p-values adjusted for multiple comparisons
#> the lower triangle: unadjusted p-values.
#> 
#> Note: In the correlation matrix,
#> the upper triangle: p-values adjusted for multiple comparisons
#> the lower triangle: unadjusted p-values.
#> 
#> Note: In the correlation matrix,
#> the upper triangle: p-values adjusted for multiple comparisons
#> the lower triangle: unadjusted p-values.
#> 
#> Warning: Individual plots in the combined `grouped_` plot
#> can't be further modified with `ggplot2` functions.
#> 
```

![](https://i.imgur.com/8U5i5kO.png)

``` r

ggstatsplot::ggcorrmat(
data = ggplot2::msleep,
cor.vars = 6:10,
p.adjust.method = "BH",
output = "ci"
)
#> Note: In the correlation matrix,
#> the upper triangle: p-values adjusted for multiple comparisons
#> the lower triangle: unadjusted p-values.
#> 
#> # A tibble: 10 x 7
#>    pair             r  lower   upper         p lower.adj upper.adj
#>    <chr>        <dbl>  <dbl>   <dbl>     <dbl>     <dbl>     <dbl>
#>  1 slp_t-slp_r  0.752  0.617  0.844  2.92e- 12   0.543     0.873  
#>  2 slp_t-slp_c -0.474 -0.706 -0.150  6.17e-  3  -0.776     0.00641
#>  3 slp_t-awake -1.000 -1.000 -1.000  2.42e-226  -1.000    -1.000  
#>  4 slp_t-brnwt -0.360 -0.569 -0.108  6.35e-  3  -0.643     0.00813
#>  5 slp_r-slp_c -0.338 -0.614  0.0120 5.84e-  2  -0.703     0.168  
#>  6 slp_r-awake -0.752 -0.844 -0.617  2.91e- 12  -0.873    -0.543  
#>  7 slp_r-brnwt -0.221 -0.476  0.0670 1.31e-  1  -0.567     0.191  
#>  8 slp_c-awake  0.474  0.150  0.706  6.17e-  3  -0.00641   0.776  
#>  9 slp_c-brnwt  0.852  0.709  0.927  2.42e-  9   0.618     0.947  
#> 10 awake-brnwt  0.360  0.108  0.569  6.35e-  3  -0.00813   0.643

ggstatsplot::grouped_ggcorrmat(
  data = datasets::iris,
  grouping.var = Species,
  p.adjust.method = "holm",
  cor.vars = 6:10,
  output = "ci"
)
#> Error in inds_combine(.vars, ind_list): Position must be between 0 and n
```

<sup>Created on 2019-01-04 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>