### PR TITLE
Proposed fix for #132

### DIFF
--- a/R/ggbetweenstats.R
+++ b/R/ggbetweenstats.R
@@ -732,11 +732,11 @@ ggbetweenstats <- function(data,
     ggplot2::theme(legend.position = "none")
 
   # don't do scale restriction in case of post hoc comparisons
-  if (!isTRUE(pairwise.comparisons)) {
-    plot <- plot +
-      ggplot2::coord_cartesian(ylim = c(min(data$y), max(data$y))) +
-      ggplot2::scale_y_continuous(limits = c(min(data$y), max(data$y)))
-  }
+#  if (!isTRUE(pairwise.comparisons)) {
+#    plot <- plot +
+#      ggplot2::coord_cartesian(ylim = c(min(data$y), max(data$y))) +
+#      ggplot2::scale_y_continuous(limits = c(min(data$y), max(data$y)))
+#  }
 
   # choosing palette
   plot <- plot +

--- a/tests/testthat/test_ggbetweenstats.R
+++ b/tests/testthat/test_ggbetweenstats.R
@@ -154,10 +154,7 @@ testthat::test_that(
     )
 
     # limits of data
-    testthat::expect_equal(ggplot2::layer_scales(p)$y$limits,
-      c(0.00014, 5.71200),
-      tolerance = 1e-3
-    )
+    testthat::expect_null(ggplot2::layer_scales(p)$y$limits)
 
     # checking x-axis sample size labels
     testthat::expect_identical(


### PR DESCRIPTION
See issue thread for more detail.

``` r
set.seed(123)
library(ggplot2)
library(ggstatsplot)
# more detailed function call
ggstatsplot::ggbetweenstats(
  data = datasets::morley,
  x = Expt,
  y = Speed,
  conf.level = 0.99,
  xlab = "The experiment number",
  ylab = "Speed-of-light measurement",
  pairwise.comparisons = TRUE,
  pairwise.display = "all",
  ggplot.component = ggplot2::scale_y_continuous(breaks = seq(500, 1200, 200), limits = (c(500,1200)))
)
#> Note: 99% CI for effect size estimate was computed with 100 bootstrap samples.
#> 
#> # A tibble: 10 x 11
#>    group1 group2 mean.difference conf.low conf.high    se t.value    df
#>    <chr>  <chr>            <dbl>    <dbl>     <dbl> <dbl>   <dbl> <dbl>
#>  1 1      2                -53     -132.     25.7    19.2   1.95   30.6
#>  2 1      3                -64     -148.     20.4    20.8   2.18   35.3
#>  3 1      4                -88.5   -167.    -10.1    19.1   3.27   30.2
#>  4 1      5                -77.5   -154.     -0.641  18.7   2.94   28.5
#>  5 2      3                -11      -75.2    53.2    15.8   0.492  35.7
#>  6 2      4                -35.5    -90.4    19.4    13.6   1.85   38.0
#>  7 2      5                -24.5    -76.9    27.9    12.9   1.34   37.5
#>  8 3      4                -24.5    -88.3    39.3    15.7   1.10   35.4
#>  9 3      5                -13.5    -75.3    48.3    15.2   0.63   33.6
#> 10 4      5                 11      -40.8    62.8    12.8   0.608  37.6
#> # … with 3 more variables: p.value <dbl>, significance <chr>,
#> #   p.value.label <chr>
#> Note: Shapiro-Wilk Normality Test for Speed-of-light measurement : p-value = 0.514
#> 
#> Note: Bartlett's test for homogeneity of variances for factor The experiment number : p-value = 0.021
#> 
```

![](https://i.imgur.com/qVTzpjV.png)

``` r

# more detailed function call
ggstatsplot::ggbetweenstats(
  data = datasets::morley,
  x = Expt,
  y = Speed,
  conf.level = 0.99,
  xlab = "The experiment number",
  ylab = "Speed-of-light measurement",
  pairwise.comparisons = FALSE,
  pairwise.display = "all",
  ggplot.component = ggplot2::scale_y_continuous(breaks = seq(500, 1200, 200), limits = (c(500,1200)))
)
#> Note: 99% CI for effect size estimate was computed with 100 bootstrap samples.
#> 
#> Note: Shapiro-Wilk Normality Test for Speed-of-light measurement : p-value = 0.514
#> 
#> Note: Bartlett's test for homogeneity of variances for factor The experiment number : p-value = 0.021
#> 
```

![](https://i.imgur.com/BLjFkiA.png)

<sup>Created on 2019-01-09 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>