### PR TITLE
bugfixes for new version of metaBMA(>=0.6.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 # documentation at https://docs.travis-ci.com/user/languages/r
 
 language: r
-r:
-  - release
-  - devel
-
 sudo: true
 dist: trusty
 cache: packages
+latex: true
 warnings_are_errors: true
 
 repos:
@@ -19,62 +16,156 @@ env:
     - R_MAX_NUM_DLLS=999
     - _R_CHECK_FORCE_SUGGESTS_=true
     - _R_CHECK_CRAN_INCOMING_=true
+    - MAKEFLAGS="-j 2"
 
 #r_check_args: "--run-dontrun"
 
-r_binary_packages:
-  - stringi
-  - magrittr
-  - curl
-  - jsonlite
-  - Rcpp
-  - RcppEigen
-  - openssl
-  - utf8
-  - gss
-  - haven
-  - minqa
-  - mvtnorm
-  - nloptr
-  - SparseM
-  - httpuv
-  - markdown
-  - sem
-  - readxl
-  - openxlsx
-  - pander
-  - lme4
-  - psych
-  - git2r
-  - data.table
-  - rjags
 
-r_packages:
-  - rlang
-  - bindrcpp
-  - purrr
-  - tidyr
-  - dplyr
-  - readr
-  - ggthemes
-  - jcolors
-  - oompaBase
-  - palr
-  - coin
-  - jmv
-  - sjstats
-  - WRS2
-  - scico
-  - viridisLite
-
-r_github_packages:
-  - jimhester/lintr
-  - r-lib/covr
 
 notifications:
   email:
   on_success: change
   on_failure: change
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      r: release
+      r_binary_packages:
+        - stringi
+        - magrittr
+        - curl
+        - jsonlite
+        - Rcpp
+        - RcppEigen
+        - openssl
+        - utf8
+        - gss
+        - haven
+        - minqa
+        - mvtnorm
+        - nloptr
+        - SparseM
+        - httpuv
+        - markdown
+        - sem
+        - readxl
+        - openxlsx
+        - pander
+        - lme4
+        - psych
+        - git2r
+        - data.table
+        - rjags
+        - StanHeaders
+        - rstan
+        - LaplacesDemon
+        - logspline
+        - metaBMA
+      r_packages:
+        - rlang
+        - bindrcpp
+        - purrr
+        - tidyr
+        - dplyr
+        - readr
+        - ggthemes
+        - jcolors
+        - oompaBase
+        - palr
+        - coin
+        - jmv
+        - sjstats
+        - WRS2
+        - scico
+        - viridisLite
+        - bridgesampling
+        - rstantools
+        - BH
+        - remotes
+      r_github_packages:
+        - jimhester/lintr
+        - r-lib/covr
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    - os: linux
+      dist: trusty
+      r: devel
+      r_binary_packages:
+        - stringi
+        - magrittr
+        - curl
+        - jsonlite
+        - Rcpp
+        - RcppEigen
+        - openssl
+        - utf8
+        - gss
+        - haven
+        - minqa
+        - mvtnorm
+        - nloptr
+        - SparseM
+        - httpuv
+        - markdown
+        - sem
+        - readxl
+        - openxlsx
+        - pander
+        - lme4
+        - psych
+        - git2r
+        - data.table
+        - rjags
+        - StanHeaders
+        - rstan
+        - LaplacesDemon
+        - logspline
+        - metaBMA
+      r_packages:
+        - rlang
+        - bindrcpp
+        - purrr
+        - tidyr
+        - dplyr
+        - readr
+        - ggthemes
+        - jcolors
+        - oompaBase
+        - palr
+        - coin
+        - jmv
+        - sjstats
+        - WRS2
+        - scico
+        - viridisLite
+        - bridgesampling
+        - rstantools
+        - BH
+        - remotes
+      r_github_packages:
+        - jimhester/lintr
+        - r-lib/covr
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+before_install:
+  - mkdir -p ~/.R/
+  - echo "CXX14 = g++-7 -fPIC -flto=2" >> ~/.R/Makevars
+  - echo "CXX14FLAGS = -mtune=native -march=native -Wno-unused-variable -Wno-unused-function -Wno-unused-local-typedefs -Wno-ignored-attributes -Wno-deprecated-declarations -Wno-attributes -O3" >> ~/.R/Makevars
 
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Imports:
     jmv (>= 0.9.6.1),
     magrittr (>= 1.5),
     MCMCpack,
-    metaBMA (>= 0.3.9),
+    metaBMA (>= 0.6.1),
     metafor (>= 2.1-0),
     methods,
     paletteer (>= 0.2.1),

--- a/R/ggcoefstats.R
+++ b/R/ggcoefstats.R
@@ -320,11 +320,11 @@ ggcoefstats <- function(x,
                         component = "survival",
                         bf.message = TRUE,
                         d = "norm",
-                        d.par = c(0, 0.3),
+                        d.par = c(mean=0, sd=0.3),
                         tau = "halfcauchy",
-                        tau.par = 0.5,
-                        sample = 10000,
-                        summarize = "integrate",
+                        tau.par = c(scale=0.5),
+                        iter = 5000,
+                        summarize = "stan",
                         p.kr = TRUE,
                         p.adjust.method = "none",
                         coefficient.type = c("beta", "location", "coefficient"),
@@ -868,7 +868,7 @@ ggcoefstats <- function(x,
         output = "subtitle"
       )
 
-    # results from Bayesian random-effects meta-analysi
+    # results from Bayesian random-effects meta-analysis
     if (isTRUE(bf.message)) {
       caption <-
         bf_meta_message(
@@ -880,7 +880,7 @@ ggcoefstats <- function(x,
           d.par = d.par,
           tau = tau,
           tau.par = tau.par,
-          sample = sample,
+          iter = iter,
           summarize = summarize
         )
     }

--- a/R/helpers_ggcoefstats.R
+++ b/R/helpers_ggcoefstats.R
@@ -874,7 +874,6 @@ bf_meta_message <- function(data,
     tau = tau,
     iter = iter,
     summarize = summarize,
-    # cores = cores,  # note: sampling with cores=1 is faster than cores=4
     ...
   )
 

--- a/R/helpers_ggcoefstats.R
+++ b/R/helpers_ggcoefstats.R
@@ -762,6 +762,13 @@ subtitle_meta_ggcoefstats <- function(data,
 #'
 #' @inheritParams subtitle_meta_ggcoefstats
 #' @inheritParams metaBMA::meta_random
+#' @param d the prior distribution of the average effect size \eqn{d} specified
+#'   either as the type of family (e.g., \code{"norm"}) or via \code{\link[metaBMA]{prior}}
+#' @param d.par prior parameters for \eqn{d} (only used if \code{d} specifies the type of family)
+#' @param tau the prior distribution of the between-study heterogeneity \eqn{\tau} specified
+#'   either as a character value (e.g., \code{"halfcauchy"}) or via \code{\link[metaBMA]{prior}}
+#' @param tau.par prior parameters for \eqn{\tau}  (only used if \code{tau} specifies the type of family)
+#' @param iter number of MCMC iterations using Stan.
 #'
 #' @examples
 #'
@@ -794,12 +801,12 @@ subtitle_meta_ggcoefstats <- function(data,
 #'     class = c("tbl_df", "tbl", "data.frame")
 #'   ))
 #'
-#' # getting bayes factor in favor of null hypothesis
+#' # getting Bayes factor in favor of null hypothesis
 #' ggstatsplot::bf_meta_message(
 #'   data = df,
 #'   k = 3,
-#'   sample = 50,
-#'   messages = FALSE
+#'   iter = 1500,
+#'   messages = TRUE
 #' )
 #' }
 #'
@@ -809,11 +816,11 @@ subtitle_meta_ggcoefstats <- function(data,
 bf_meta_message <- function(data,
                             k = 2,
                             d = "norm",
-                            d.par = c(0, 0.3),
+                            d.par = c(mean = 0, sd = 0.3),
                             tau = "halfcauchy",
-                            tau.par = 0.5,
-                            sample = 10000,
-                            summarize = "integrate",
+                            tau.par = c(scale = 0.5),
+                            iter = 10000,
+                            summarize = "stan",
                             caption = NULL,
                             messages = TRUE,
                             ...) {
@@ -841,18 +848,33 @@ bf_meta_message <- function(data,
       dplyr::mutate(.data = ., term = as.character(term))
   }
 
+  # check defintion of priors for d and tau
+  # Note: "d.par" and "tau.par" are deprecated in metaBMA (>= 0.6.1)
+  if (class(d) == "character"){
+    d <- metaBMA::prior(family = d, param = d.par)
+  } else if (!class(d) == "prior"){
+    stop("The argument 'd' must be ",
+         "\n  (A) a character such as 'norm' specifying the family of prior distribution",
+         "\n  (B) a prior distribution specified via metaBMA::prior()")
+  }
+  if (class(tau) == "character"){
+    tau <- metaBMA::prior(family = tau, param = tau.par)
+  } else if (!class(tau) == "prior"){
+    stop("The argument 'tau' must be ",
+         "\n  (A) a character such as 'halfcauchy' specifying the family of prior distribution",
+         "\n  (B) a non-negative prior distribution specified via metaBMA::prior()")
+  }
+
   # extracting results from random-effects meta-analysis
   bf_meta <- metaBMA::meta_random(
     y = data$estimate,
     SE = data$std.error,
     labels = data$term,
     d = d,
-    d.par = d.par,
     tau = tau,
-    tau.par = tau.par,
-    sample = sample,
+    iter = iter,
     summarize = summarize,
-    method = "parallel",
+    # cores = cores,  # note: sampling with cores=1 is faster than cores=4
     ...
   )
 
@@ -894,10 +916,10 @@ bf_meta_message <- function(data,
       ),
       env = list(
         top.text = caption,
-        bf = specify_decimal_p(x = -log(bf_meta$BF[[1]]), k = k),
-        d.pmean = specify_decimal_p(x = df_estimates$Mean[[1]], k = k),
-        d.pmean.LB = specify_decimal_p(x = df_estimates$HPD95lower[[1]], k = k),
-        d.pmean.UB = specify_decimal_p(x = df_estimates$HPD95upper[[1]], k = k)
+        bf = specify_decimal_p(x = log(bf_meta$BF["random_H0","random_H1"]), k = k),
+        d.pmean = specify_decimal_p(x = df_estimates$mean[[1]], k = k),
+        d.pmean.LB = specify_decimal_p(x = df_estimates$hpd95_lower[[1]], k = k),
+        d.pmean.UB = specify_decimal_p(x = df_estimates$hpd95_upper[[1]], k = k)
       )
     )
 

--- a/man/bf_meta_message.Rd
+++ b/man/bf_meta_message.Rd
@@ -4,36 +4,41 @@
 \alias{bf_meta_message}
 \title{Bayes factor message for random-effects meta-analysis}
 \usage{
-bf_meta_message(data, k = 2, d = "norm", d.par = c(0, 0.3),
-  tau = "halfcauchy", tau.par = 0.5, sample = 10000,
-  summarize = "integrate", caption = NULL, messages = TRUE, ...)
+bf_meta_message(data, k = 2, d = "norm", d.par = c(mean = 0, sd =
+  0.3), tau = "halfcauchy", tau.par = c(scale = 0.5), iter = 10000,
+  summarize = "stan", caption = NULL, messages = TRUE, ...)
 }
 \arguments{
-\item{data}{A dataframe. It \strong{must} contain columns named \code{estimate}
-(corresponding estimates of coefficients or other quantities of interest)
-and \code{std.error} (the standard error of the regression term).}
+\item{data}{data frame containing the variables for effect size \code{y},
+standard error \code{SE}, \code{labels}, and moderators per study.}
 
 \item{k}{Number of digits after decimal point (should be an integer)
 (Default: \code{k = 2}).}
 
-\item{d}{type of prior for mean effect \eqn{d} (see \code{\link{prior}})}
+\item{d}{the prior distribution of the average effect size \eqn{d} specified
+either as the type of family (e.g., \code{"norm"}) or via \code{\link[metaBMA]{prior}}}
 
-\item{d.par}{prior parameters for \eqn{d}}
+\item{d.par}{prior parameters for \eqn{d} (only used if \code{d} specifies the type of family)}
 
-\item{tau}{type of prior for standard deviation of study effects \eqn{\tau} in random-effects meta-analysis (i.e., the SD of d across studies; see \code{\link{prior}})}
+\item{tau}{the prior distribution of the between-study heterogeneity \eqn{\tau} specified
+either as a character value (e.g., \code{"halfcauchy"}) or via \code{\link[metaBMA]{prior}}}
 
-\item{tau.par}{prior parameters for \eqn{\tau}}
+\item{tau.par}{prior parameters for \eqn{\tau}  (only used if \code{tau} specifies the type of family)}
 
-\item{sample}{number of samples in JAGS after burn-in and thinning (see \code{\link[runjags]{run.jags}}). Samples are used to get posterior  estimates for each study effect (which will show shrinkage). Only works for priors defined in \code{\link{prior}}.}
+\item{iter}{number of MCMC iterations using Stan.}
 
-\item{summarize}{whether and to compute parameter summaries (mean, median, SD, 95\% quantile interval, HPD interval). If \code{summarize = "integrate"}, numerical integration is used  (which is precise but can require some seconds of computing time), \code{summarize = "jags"} summarizes the JAGS samples, and \code{summarize = "none"} suppresses parameter summaries.}
+\item{summarize}{how to estimate parameter summaries (mean, median, SD,
+etc.): Either by numerical integration (\code{summarize = "integrate"}) or
+based on MCMC/Stan samples (\code{summarize = "stan"}).}
 
 \item{caption}{The text for the plot caption.}
 
 \item{messages}{Decides whether messages references, notes, and warnings are
 to be displayed (Default: \code{TRUE}).}
 
-\item{...}{arguments passed to \link[runjags]{run.jags} (e.g., MCMC parameters such as \code{sample}, \code{burnin}, \code{n.chains}, \code{thin} or \code{method="parallel"})}
+\item{...}{further arguments passed to \code{rstan::sampling} (see
+\code{\link[rstan]{stanmodel-method-sampling}}). For instance:
+\code{warmup=500}, \code{chains=4}, \code{control=list(adapt_delta=.95)}).}
 }
 \description{
 Bayes factor message for random-effects meta-analysis
@@ -69,12 +74,12 @@ library(metaBMA)
     class = c("tbl_df", "tbl", "data.frame")
   ))
 
-# getting bayes factor in favor of null hypothesis
+# getting Bayes factor in favor of null hypothesis
 ggstatsplot::bf_meta_message(
   data = df,
   k = 3,
-  sample = 50,
-  messages = FALSE
+  iter = 1500,
+  messages = TRUE
 )
 }
 

--- a/man/combine_plots.Rd
+++ b/man/combine_plots.Rd
@@ -31,7 +31,7 @@ Must be specified if any of the graphs are complex (e.g. faceted) and alignment 
   \item{rel_widths}{(optional) Numerical vector of relative columns widths. For example, in a two-column
 grid, \code{rel_widths = c(2, 1)} would make the first column twice as wide as the
 second column.}
-  \item{rel_heights}{(optional) Numerical vector of relative rows heights. Works just as
+  \item{rel_heights}{(optional) Numerical vector of relative columns heights. Works just as
 \code{rel_widths} does, but for rows rather than columns.}
   \item{labels}{(optional) List of labels to be added to the plots. You can also set \code{labels="AUTO"} to
 auto-generate upper-case labels or \code{labels="auto"} to auto-generate lower-case labels.}
@@ -52,7 +52,6 @@ down on the plot canvas. Can be a single value (applied to all labels) or a vect
   \item{scale}{Individual number or vector of numbers greater than 0. Enables you to scale the size of all or
 select plots. Usually it's preferable to set margins instead of using \code{scale}, but \code{scale} can
 sometimes be more powerful.}
-  \item{greedy}{(optional) How should margins be adjusted during alignment. See \code{\link[=align_plots]{align_plots()}} for details.}
   \item{cols}{Deprecated. Use \code{ncol}.}
   \item{rows}{Deprecated. Use \code{nrow}.}
 }}

--- a/man/ggcoefstats.Rd
+++ b/man/ggcoefstats.Rd
@@ -7,9 +7,9 @@ caption.}
 \usage{
 ggcoefstats(x, output = "plot", statistic = NULL, scales = NULL,
   conf.method = "Wald", conf.type = "Wald", component = "survival",
-  bf.message = TRUE, d = "norm", d.par = c(0, 0.3),
-  tau = "halfcauchy", tau.par = 0.5, sample = 10000,
-  summarize = "integrate", p.kr = TRUE, p.adjust.method = "none",
+  bf.message = TRUE, d = "norm", d.par = c(mean = 0, sd = 0.3),
+  tau = "halfcauchy", tau.par = c(scale = 0.5), iter = 5000,
+  summarize = "stan", p.kr = TRUE, p.adjust.method = "none",
   coefficient.type = c("beta", "location", "coefficient"),
   by.class = FALSE, effsize = "eta", partial = TRUE, nboot = 500,
   meta.analytic.effect = FALSE, point.color = "blue", point.size = 3,
@@ -51,7 +51,7 @@ dataframe of results from \code{broom::tidy}) or \code{"glance"} (object from
 \code{ggcoefstats} is a dataframe in which case the function wouldn't know what
 kind of model it is dealing with.}
 
-\item{scales}{scales on which to report the variables: for random effects, the choices are \sQuote{"sdcor"} (standard deviations and correlations: the default if \code{scales} is \code{NULL}) or \sQuote{"vcov"} (variances and covariances). \code{NA} means no transformation, appropriate e.g. for fixed effects.}
+\item{scales}{scales on which to report the variables: for random effects, the choices are \sQuote{"sdcor"} (standard deviations and correlations: the default if \code{scales} is \code{NULL}) or \sQuote{"vcov"} (variances and covariances). \code{NA} means no transformation, appropriate e.g. for fixed effects; inverse-link transformations (exponentiation or logistic) are not yet implemented, but may be in the future.}
 
 \item{conf.method}{Character describing method for computing confidence
 intervals (for more, see \code{?lme4::confint.merMod} and
@@ -62,9 +62,8 @@ are: \code{"profile"}, \code{"boot"}). For MCMC or brms fit model objects (Stan,
 JAGS, etc.), the default is \code{"quantile"}, while the only other options is
 \code{"HPDinterval"}.}
 
-\item{conf.type}{Whether to use \code{"profile"} or \code{"Wald"} confidendence
-intervals, passed to the \code{type} argument of \code{\link[ordinal:confint.clm]{ordinal::confint.clm()}}.
-Defaults to \code{"profile"}.}
+\item{conf.type}{the type of confidence interval
+(see \code{\link[ordinal:confint.clm]{ordinal::confint.clm()}})}
 
 \item{component}{Character specifying whether to tidy the survival or
 the longitudinal component of the model. Must be either \code{"survival"} or
@@ -75,17 +74,21 @@ Bayesian meta-analysis assuming that the effect size \emph{d} varies across
 studies with standard deviation \emph{t} (i.e., a random-effects analysis)
 should be displayed in caption. Defaults to \code{TRUE}.}
 
-\item{d}{type of prior for mean effect \eqn{d} (see \code{\link{prior}})}
+\item{d}{the prior distribution of the average effect size \eqn{d} specified
+either as the type of family (e.g., \code{"norm"}) or via \code{\link[metaBMA]{prior}}}
 
-\item{d.par}{prior parameters for \eqn{d}}
+\item{d.par}{prior parameters for \eqn{d} (only used if \code{d} specifies the type of family)}
 
-\item{tau}{type of prior for standard deviation of study effects \eqn{\tau} in random-effects meta-analysis (i.e., the SD of d across studies; see \code{\link{prior}})}
+\item{tau}{the prior distribution of the between-study heterogeneity \eqn{\tau} specified
+either as a character value (e.g., \code{"halfcauchy"}) or via \code{\link[metaBMA]{prior}}}
 
-\item{tau.par}{prior parameters for \eqn{\tau}}
+\item{tau.par}{prior parameters for \eqn{\tau}  (only used if \code{tau} specifies the type of family)}
 
-\item{sample}{number of samples in JAGS after burn-in and thinning (see \code{\link[runjags]{run.jags}}). Samples are used to get posterior  estimates for each study effect (which will show shrinkage). Only works for priors defined in \code{\link{prior}}.}
+\item{iter}{number of MCMC iterations using Stan.}
 
-\item{summarize}{whether and to compute parameter summaries (mean, median, SD, 95\% quantile interval, HPD interval). If \code{summarize = "integrate"}, numerical integration is used  (which is precise but can require some seconds of computing time), \code{summarize = "jags"} summarizes the JAGS samples, and \code{summarize = "none"} suppresses parameter summaries.}
+\item{summarize}{how to estimate parameter summaries (mean, median, SD,
+etc.): Either by numerical integration (\code{summarize = "integrate"}) or
+based on MCMC/Stan samples (\code{summarize = "stan"}).}
 
 \item{p.kr}{Logical, if \code{TRUE}, the computation of \emph{p}-values for \code{lmer} is
 based on conditional F-tests with Kenward-Roger approximation for the df.

--- a/man/ggscatterstats.Rd
+++ b/man/ggscatterstats.Rd
@@ -69,7 +69,7 @@ e.g. \code{"auto"}, \code{"lm"}, \code{"glm"}, \code{"gam"}, \code{"loess"} or a
 \code{MASS::rlm} or \code{mgcv::gam}, \code{stats::lm}, or \code{stats::loess}.
 
 For \code{method = "auto"} the smoothing method is chosen based on the
-size of the largest group (across all panels). \code{\link[=loess]{loess()}} is
+size of the largest group (across all panels). \code{\link[stats:loess]{stats::loess()}} is
 used for less than 1,000 observations; otherwise \code{\link[mgcv:gam]{mgcv::gam()}} is
 used with \code{formula = y ~ s(x, bs = "cs")}. Somewhat anecdotally,
 \code{loess} gives a better appearance, but is \eqn{O(N^{2})}{O(N^2)} in memory,

--- a/man/grouped_ggscatterstats.Rd
+++ b/man/grouped_ggscatterstats.Rd
@@ -78,7 +78,7 @@ e.g. \code{"auto"}, \code{"lm"}, \code{"glm"}, \code{"gam"}, \code{"loess"} or a
 \code{MASS::rlm} or \code{mgcv::gam}, \code{stats::lm}, or \code{stats::loess}.
 
 For \code{method = "auto"} the smoothing method is chosen based on the
-size of the largest group (across all panels). \code{\link[=loess]{loess()}} is
+size of the largest group (across all panels). \code{\link[stats:loess]{stats::loess()}} is
 used for less than 1,000 observations; otherwise \code{\link[mgcv:gam]{mgcv::gam()}} is
 used with \code{formula = y ~ s(x, bs = "cs")}. Somewhat anecdotally,
 \code{loess} gives a better appearance, but is \eqn{O(N^{2})}{O(N^2)} in memory,

--- a/tests/testthat/test_bf_meta_message.R
+++ b/tests/testthat/test_bf_meta_message.R
@@ -42,17 +42,28 @@ testthat::test_that(
       data = df1,
       k = 3,
       messages = TRUE,
-      sample = 50
+      iter = 2000
     )
     set.seed(123)
     subtitle2 <- ggstatsplot::bf_meta_message(
       data = df2,
       k = 3,
       messages = FALSE,
-      sample = 50
+      iter = 2000
+    )
+    # test prior defaults and use of metaBMA::prior()
+    set.seed(123)
+    subtitle3 <- ggstatsplot::bf_meta_message(
+      data = df2,
+      k = 3,
+      messages = FALSE,
+      d = metaBMA::prior("norm", c(0,.3)),
+      tau = metaBMA::prior("halfcauchy", c(.5)),
+      iter = 2000
     )
 
     testthat::expect_identical(subtitle1, subtitle2)
+    testthat::expect_identical(subtitle1, subtitle3)
     testthat::expect_identical(subtitle1, ggplot2::expr(atop(
       displaystyle(NULL),
       expr = paste(
@@ -64,12 +75,12 @@ testthat::test_that(
         ", ",
         italic("d")["mean"]^"posterior",
         " = ",
-        "0.491",
+        "0.492",
         ", CI"["95%"],
         " [",
-        "0.147",
+        "0.161",
         ", ",
-        "0.775",
+        "0.786",
         "]"
       )
     )))

--- a/tests/testthat/test_bf_meta_message.R
+++ b/tests/testthat/test_bf_meta_message.R
@@ -49,6 +49,10 @@ testthat::test_that(
       data = df2,
       k = 3,
       messages = FALSE,
+      d = "norm",
+      d.par = c(0, .3),
+      tau = "halfcauchy",
+      tau.par = .5,
       iter = 2000
     )
     # test prior defaults and use of metaBMA::prior()
@@ -87,5 +91,9 @@ testthat::test_that(
 
     # expecting error
     testthat::expect_error(ggstatsplot::bf_meta_message(df3))
+    testthat::expect_error(
+      ggstatsplot::bf_meta_message(data = df2,
+                                   k = 3,
+                                   d = 5, tau = 7))
   }
 )

--- a/tests/testthat/test_bf_meta_message.R
+++ b/tests/testthat/test_bf_meta_message.R
@@ -42,7 +42,8 @@ testthat::test_that(
       data = df1,
       k = 3,
       messages = TRUE,
-      iter = 2000
+      iter = 2000,
+      summarize="integrate"
     )
     set.seed(123)
     subtitle2 <- ggstatsplot::bf_meta_message(
@@ -53,7 +54,8 @@ testthat::test_that(
       d.par = c(0, .3),
       tau = "halfcauchy",
       tau.par = .5,
-      iter = 2000
+      iter = 2000,
+      summarize="integrate"
     )
     # test prior defaults and use of metaBMA::prior()
     set.seed(123)
@@ -63,7 +65,8 @@ testthat::test_that(
       messages = FALSE,
       d = metaBMA::prior("norm", c(0,.3)),
       tau = metaBMA::prior("halfcauchy", c(.5)),
-      iter = 2000
+      iter = 2000,
+      summarize="integrate"
     )
 
     testthat::expect_identical(subtitle1, subtitle2)
@@ -79,12 +82,12 @@ testthat::test_that(
         ", ",
         italic("d")["mean"]^"posterior",
         " = ",
-        "0.492",
+        "0.491",
         ", CI"["95%"],
         " [",
-        "0.161",
+        "0.144",
         ", ",
-        "0.786",
+        "0.772",
         "]"
       )
     )))

--- a/tests/testthat/test_ggcoefstats.R
+++ b/tests/testthat/test_ggcoefstats.R
@@ -882,7 +882,8 @@ testthat::test_that(
         k = 3,
         meta.analytic.effect = TRUE,
         bf.message = TRUE,
-        sample = 1000,
+        iter = 2500,
+        summarize="int",
         messages = FALSE
       )
 
@@ -988,9 +989,9 @@ testthat::test_that(
           "0.110",
           ", CI"["95%"],
           " [",
-          "-0.175",
+          "-0.178",
           ", ",
-          "0.415",
+          "0.412",
           "]"
         )
       )),


### PR DESCRIPTION
Due to many changes in the new version of the package `metaBMA` (e.g., Stan instead of JAGS; priors are defined via a function; the BF is stored as a matrix), `ggstatsplot::bf_meta_message` does not work anymore.

This pull request fixes these issues and has been tested via `R CMD CHECK --as-cran`

Edit: Note that the installation of `metaBMA` now requires the compilation of Stan (with C++14 standard). I am not sure whether this works well with continuous-integration.