### PR TITLE
implementing changes for upcoming paletteer release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     metaBMA (>= 0.6.2),
     metafor (>= 2.1-0),
     pairwiseComparisons (>= 0.1.2),
-    paletteer (>= 0.2.1),
+    paletteer (>= 0.2.1.9000),
     parameters (>= 0.3.0),
     psych (>= 1.8.12),
     purrr (>= 0.3.3),
@@ -72,6 +72,8 @@ Suggests:
     stringr,
     survival,
     testthat
+Remotes:
+    EmilHvitfeldt/paletteer
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/R/ggbarstats.R
+++ b/R/ggbarstats.R
@@ -240,8 +240,7 @@ ggbarstats <- function(data,
       ) +
       ggplot2::guides(fill = ggplot2::guide_legend(title = legend.title)) +
       paletteer::scale_fill_paletteer_d(
-        package = !!package,
-        palette = !!palette,
+        palette = paste0(package, "::", palette),
         direction = direction,
         name = "",
         labels = unique(legend.labels)

--- a/R/ggbetweenstats.R
+++ b/R/ggbetweenstats.R
@@ -101,6 +101,10 @@
 #'   be sorted based on increasing values of `y`-axis variable. If
 #'   `"descending"`, the opposite. If `"none"`, no sorting will happen.
 #' @param sort.fun The function used to sort (default: `mean`).
+#' @param package Name of package from which the palette is desired as string
+#' or symbol.
+#' @param palette Name of palette as string or symbol.
+#' @param direction Either `1` or `-1`. If `-1` the palette will be reversed.
 #' @param return Character that describes what is to be returned: can be
 #'   `"plot"` (default) or `"subtitle"` or `"caption"`. Setting this to
 #'   `"subtitle"` will return the expression containing statistical results. If
@@ -108,7 +112,6 @@
 #'   Setting this to `"caption"` will return the expression containing details
 #'   about Bayes Factor analysis, but valid only when `type = "parametric"` and
 #'   `bf.message = TRUE`, otherwise this will return a `NULL`.
-#' @inheritParams paletteer::scale_color_paletteer_d
 #' @inheritParams theme_ggstatsplot
 #' @inheritParams statsExpressions::expr_anova_parametric
 #' @inheritParams statsExpressions::expr_t_parametric

--- a/R/ggcoefstats.R
+++ b/R/ggcoefstats.R
@@ -114,6 +114,10 @@
 #' @param stats.label.args Additional arguments that will be passed to `ggrepel
 #'   geom_label_repel` geom. Please see documentation for that function to know
 #'   more about these arguments.
+#' @param package Name of package from which the palette is desired as string
+#' or symbol.
+#' @param palette Name of palette as string or symbol.
+#' @param direction Either `1` or `-1`. If `-1` the palette will be reversed.
 #' @param only.significant If `TRUE`, only stats labels for significant effects
 #'   is shown (Default: `FALSE`). This can be helpful when a large number of
 #'   regression coefficients are to be displayed in a single plot. Relevant only
@@ -128,7 +132,6 @@
 #' @inheritParams broom::tidy.polr
 #' @inheritParams broom::tidy.mjoint
 #' @inheritParams theme_ggstatsplot
-#' @inheritParams paletteer::paletteer_d
 #' @inheritParams subtitle_meta_ggcoefstats
 #' @inheritParams ggbetweenstats
 #'
@@ -921,8 +924,7 @@ ggcoefstats <- function(x,
       if (is.null(stats.label.color)) {
         stats.label.color <-
           paletteer::paletteer_d(
-            package = !!package,
-            palette = !!palette,
+            palette = paste0(package, "::", palette),
             n = count_term,
             direction = direction,
             type = "discrete"

--- a/R/ggcorrmat.R
+++ b/R/ggcorrmat.R
@@ -82,8 +82,11 @@
 #'   `insig = "pch"`). Defaults are `pch.col = "#F0E442"` and `pch.cex = 10`.
 #' @param tl.cex,tl.col,tl.srt The size, the color, and the string rotation of
 #'   text label (variable names, i.e.).
+#' @param package Name of package from which the palette is desired as string
+#' or symbol.
+#' @param palette Name of palette as string or symbol.
+#' @param direction Either `1` or `-1`. If `-1` the palette will be reversed.
 #' @inheritParams theme_ggstatsplot
-#' @inheritParams paletteer::paletteer_d
 #' @inheritParams ggscatterstats
 #'
 #' @import ggplot2
@@ -327,8 +330,7 @@ ggcorrmat <- function(data,
   # if user has not specified colors, then use a color palette
   if (is.null(colors)) {
     colors <- paletteer::paletteer_d(
-      package = !!package,
-      palette = !!palette,
+      palette = paste0(package, "::", palette),
       n = 3,
       direction = direction,
       type = "discrete"

--- a/R/ggpiestats.R
+++ b/R/ggpiestats.R
@@ -33,12 +33,15 @@
 #'   labels (Default: `white`).
 #' @param label.fill.alpha Numeric that specifies fill color transparency or
 #'   `"alpha"` for slice/bar labels (Default: `1` range `0` to `1`).
+#' @param package Name of package from which the palette is desired as string
+#' or symbol.
+#' @param palette Name of palette as string or symbol.
+#' @param direction Either `1` or `-1`. If `-1` the palette will be reversed.
 #' @param bf.message Logical that decides whether to display a caption with
 #'   results from Bayes Factor test in favor of the null hypothesis (default:
 #'   `FALSE`).
 #' @inheritParams statsExpressions::bf_contingency_tab
 #' @inheritParams statsExpressions::expr_contingency_tab
-#' @inheritParams paletteer::scale_fill_paletteer_d
 #' @inheritParams theme_ggstatsplot
 #' @inheritParams gghistostats
 #' @inheritParams cat_label_df
@@ -296,8 +299,7 @@ ggpiestats <- function(data,
   p <- p +
     ggplot2::scale_y_continuous(breaks = NULL) +
     paletteer::scale_fill_paletteer_d(
-      package = !!package,
-      palette = !!palette,
+      palette = paste0(package, "::", palette),
       direction = direction,
       name = "",
       labels = unique(legend.labels)

--- a/R/ggscatterstats.R
+++ b/R/ggscatterstats.R
@@ -23,6 +23,10 @@
 #'   5x wider and 5x taller than the marginal plots.
 #' @param margins Character describing along which margins to show the plots.
 #'   Any of the following arguments are accepted: `"both"`, `"x"`, `"y"`.
+#' @param package Name of package from which the palette is desired as string
+#' or symbol.
+#' @param direction Either `1` or `-1`. If `-1` the palette will be reversed.
+#' @param palette Name of palette as string or symbol.
 #' @param xfill,yfill Character describing color fill for `x` and `y` axes
 #'   marginal distributions (default: `"#009E73"` (for `x`) and `"#D55E00"` (for
 #'   `y`)). If set to `NULL`, manual specification of colors will be turned off
@@ -42,7 +46,6 @@
 #' @inheritParams statsExpressions::expr_corr_test
 #' @inheritParams ggplot2::geom_smooth
 #' @inheritParams theme_ggstatsplot
-#' @inheritParams paletteer::paletteer_d
 #' @inheritParams ggbetweenstats
 #'
 #' @import ggplot2
@@ -274,8 +277,7 @@ ggscatterstats <- function(data,
   if (is.null(xfill) || is.null(yfill)) {
     colors <-
       paletteer::paletteer_d(
-        package = !!package,
-        palette = !!palette,
+        palette = paste0(package, "::", palette),
         n = 2,
         direction = direction,
         type = "discrete"

--- a/R/helpers_ggbetweenstats_graphics.R
+++ b/R/helpers_ggbetweenstats_graphics.R
@@ -518,13 +518,11 @@ aesthetic_addon <- function(plot,
     ) +
     ggplot2::theme(legend.position = "none") +
     paletteer::scale_color_paletteer_d(
-      package = !!package,
-      palette = !!palette,
+      palette = paste0(package, "::", palette),
       direction = direction
     ) +
     paletteer::scale_fill_paletteer_d(
-      package = !!package,
-      palette = !!palette,
+      palette = paste0(package, "::", palette),
       direction = direction
     )
 

--- a/R/helpers_messages.R
+++ b/R/helpers_messages.R
@@ -168,8 +168,9 @@ grouped_message <- function() {
 #' @description A note to the user about not using the default color palette
 #'   when the number of factor levels is greater than 8, the maximum number of
 #'   colors allowed by `"Dark2"` palette from the `RColorBrewer` package.
-#'
-#' @inheritParams paletteer::scale_fill_paletteer_d
+#' @param package Name of package from which the palette is desired as string
+#' or symbol.
+#' @param palette Name of palette as string or symbol.
 #' @param min_length Minimum number of colors needed.
 #'
 #' @importFrom tibble as_tibble

--- a/man/aesthetic_addon.Rd
+++ b/man/aesthetic_addon.Rd
@@ -52,9 +52,7 @@ override some aspects of the selected \code{ggtheme}.}
 \item{package}{Name of package from which the palette is desired as string
 or symbol.}
 
-\item{palette}{If a character string (e.g., \code{"Set1"}), will use that named
-palette. If a number, will index into the list of palettes of appropriate
-type. Default palette is \code{"Dark2"}.}
+\item{palette}{Name of palette as string or symbol.}
 
 \item{direction}{Either \code{1} or \code{-1}. If \code{-1} the palette will be reversed.}
 

--- a/man/ggbarstats.Rd
+++ b/man/ggbarstats.Rd
@@ -145,7 +145,7 @@ hypothesis under the alternative, and corresponds to Gunel and Dickey's
 orientation (Default: \code{NULL} which is horizontal).}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{nboot}{Number of bootstrap samples for computing confidence interval
 for the effect size (Default: \code{100}).}
@@ -192,9 +192,7 @@ override some aspects of the selected \code{ggtheme}.}
 \item{package}{Name of package from which the palette is desired as string
 or symbol.}
 
-\item{palette}{If a character string (e.g., \code{"Set1"}), will use that named
-palette. If a number, will index into the list of palettes of appropriate
-type. Default palette is \code{"Dark2"}.}
+\item{palette}{Name of palette as string or symbol.}
 
 \item{direction}{Either \code{1} or \code{-1}. If \code{-1} the palette will be reversed.}
 

--- a/man/ggbetweenstats.Rd
+++ b/man/ggbetweenstats.Rd
@@ -158,7 +158,7 @@ should be displayed for each level of the grouping variable \code{x} (Default:
     the case of arbitrarily many samples.}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{nboot}{Number of bootstrap samples for computing confidence interval
 for the effect size (Default: \code{100}).}
@@ -253,9 +253,7 @@ override some aspects of the selected \code{ggtheme}.}
 \item{package}{Name of package from which the palette is desired as string
 or symbol.}
 
-\item{palette}{If a character string (e.g., \code{"Set1"}), will use that named
-palette. If a number, will index into the list of palettes of appropriate
-type. Default palette is \code{"Dark2"}.}
+\item{palette}{Name of palette as string or symbol.}
 
 \item{direction}{Either \code{1} or \code{-1}. If \code{-1} the palette will be reversed.}
 

--- a/man/ggcoefstats.Rd
+++ b/man/ggcoefstats.Rd
@@ -82,7 +82,7 @@ dataframe of results from \code{broom::tidy}) or \code{"glance"} (object from
 \code{ggcoefstats} is a dataframe in which case the function wouldn't know what
 kind of model it is dealing with.}
 
-\item{scales}{scales on which to report the variables: for random effects, the choices are \sQuote{"sdcor"} (standard deviations and correlations: the default if \code{scales} is \code{NULL}) or \sQuote{"vcov"} (variances and covariances). \code{NA} means no transformation, appropriate e.g. for fixed effects.}
+\item{scales}{scales on which to report the variables: for random effects, the choices are \sQuote{"sdcor"} (standard deviations and correlations: the default if \code{scales} is \code{NULL}) or \sQuote{"vcov"} (variances and covariances). \code{NA} means no transformation, appropriate e.g. for fixed effects; inverse-link transformations (exponentiation or logistic) are not yet implemented, but may be in the future.}
 
 \item{component}{Character specifying whether to tidy the survival or
 the longitudinal component of the model. Must be either \code{"survival"} or

--- a/man/ggcorrmat.Rd
+++ b/man/ggcorrmat.Rd
@@ -101,7 +101,7 @@ correlation coefficient is regarded as insignificant and flagged as such in
 the plot. This argument is relevant only when \code{output = "plot"}.}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{p.adjust.method}{What adjustment for multiple tests should be used?
 (\code{"holm"}, \code{"hochberg"}, \code{"hommel"}, \code{"bonferroni"}, \code{"BH"}, \code{"BY"},

--- a/man/ggdotplotstats.Rd
+++ b/man/ggdotplotstats.Rd
@@ -99,7 +99,7 @@ argument can be \code{"biased"} (\code{"d"} for Cohen's \emph{d}) or \code{"unbi
 or Hedge's \emph{g} (Default: \code{TRUE}).}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{nboot}{Number of bootstrap samples for computing confidence interval
 for the effect size (Default: \code{100}).}

--- a/man/gghistostats.Rd
+++ b/man/gghistostats.Rd
@@ -113,7 +113,7 @@ argument can be \code{"biased"} (\code{"d"} for Cohen's \emph{d}) or \code{"unbi
 or Hedge's \emph{g} (Default: \code{TRUE}).}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{nboot}{Number of bootstrap samples for computing confidence interval
 for the effect size (Default: \code{100}).}

--- a/man/ggpiestats.Rd
+++ b/man/ggpiestats.Rd
@@ -123,7 +123,7 @@ hypothesis under the alternative, and corresponds to Gunel and Dickey's
 \item{caption}{The text for the plot caption.}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{bf.prior}{A numeric value between \code{0.5} and \code{2} (default \code{0.707}), the
 prior width to use in calculating Bayes Factors.}
@@ -170,9 +170,7 @@ override some aspects of the selected \code{ggtheme}.}
 \item{package}{Name of package from which the palette is desired as string
 or symbol.}
 
-\item{palette}{If a character string (e.g., \code{"Set1"}), will use that named
-palette. If a number, will index into the list of palettes of appropriate
-type. Default palette is \code{"Dark2"}.}
+\item{palette}{Name of palette as string or symbol.}
 
 \item{direction}{Either \code{1} or \code{-1}. If \code{-1} the palette will be reversed.}
 

--- a/man/ggscatterstats.Rd
+++ b/man/ggscatterstats.Rd
@@ -77,7 +77,7 @@ parametric/pearson's), \code{"np"} (nonparametric/spearman), \code{"r"} (robust)
 \code{"bf"} (for bayes factor), resp.}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{bf.prior}{A numeric value between \code{0.5} and \code{2} (default \code{0.707}), the
 prior width to use in calculating Bayes Factors.}

--- a/man/ggwithinstats.Rd
+++ b/man/ggwithinstats.Rd
@@ -147,7 +147,7 @@ should be displayed for each level of the grouping variable \code{x} (Default:
 (Default: \code{k = 2}).}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{nboot}{Number of bootstrap samples for computing confidence interval
 for the effect size (Default: \code{100}).}
@@ -246,9 +246,7 @@ override some aspects of the selected \code{ggtheme}.}
 \item{package}{Name of package from which the palette is desired as string
 or symbol.}
 
-\item{palette}{If a character string (e.g., \code{"Set1"}), will use that named
-palette. If a number, will index into the list of palettes of appropriate
-type. Default palette is \code{"Dark2"}.}
+\item{palette}{Name of palette as string or symbol.}
 
 \item{direction}{Either \code{1} or \code{-1}. If \code{-1} the palette will be reversed.}
 

--- a/man/grouped_ggbarstats.Rd
+++ b/man/grouped_ggbarstats.Rd
@@ -152,7 +152,7 @@ hypothesis under the alternative, and corresponds to Gunel and Dickey's
 orientation (Default: \code{NULL} which is horizontal).}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{nboot}{Number of bootstrap samples for computing confidence interval
 for the effect size (Default: \code{100}).}
@@ -203,9 +203,7 @@ override some aspects of the selected \code{ggtheme}.}
 \item{package}{Name of package from which the palette is desired as string
 or symbol.}
 
-\item{palette}{If a character string (e.g., \code{"Set1"}), will use that named
-palette. If a number, will index into the list of palettes of appropriate
-type. Default palette is \code{"Dark2"}.}
+\item{palette}{Name of palette as string or symbol.}
 
 \item{direction}{Either \code{1} or \code{-1}. If \code{-1} the palette will be reversed.}
 

--- a/man/grouped_ggbetweenstats.Rd
+++ b/man/grouped_ggbetweenstats.Rd
@@ -168,7 +168,7 @@ should be displayed for each level of the grouping variable \code{x} (Default:
     the case of arbitrarily many samples.}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{nboot}{Number of bootstrap samples for computing confidence interval
 for the effect size (Default: \code{100}).}
@@ -269,9 +269,7 @@ override some aspects of the selected \code{ggtheme}.}
 \item{package}{Name of package from which the palette is desired as string
 or symbol.}
 
-\item{palette}{If a character string (e.g., \code{"Set1"}), will use that named
-palette. If a number, will index into the list of palettes of appropriate
-type. Default palette is \code{"Dark2"}.}
+\item{palette}{Name of palette as string or symbol.}
 
 \item{direction}{Either \code{1} or \code{-1}. If \code{-1} the palette will be reversed.}
 

--- a/man/grouped_ggcorrmat.Rd
+++ b/man/grouped_ggcorrmat.Rd
@@ -122,7 +122,7 @@ correlation coefficient is regarded as insignificant and flagged as such in
 the plot. This argument is relevant only when \code{output = "plot"}.}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{p.adjust.method}{What adjustment for multiple tests should be used?
 (\code{"holm"}, \code{"hochberg"}, \code{"hommel"}, \code{"bonferroni"}, \code{"BH"}, \code{"BY"},

--- a/man/grouped_ggdotplotstats.Rd
+++ b/man/grouped_ggdotplotstats.Rd
@@ -98,7 +98,7 @@ parametric test} (Default: \code{TRUE}).}
 \code{?WRS2::onesampb}.}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{effsize.type}{Type of effect size needed for \emph{parametric} tests. The
 argument can be \code{"biased"} (\code{"d"} for Cohen's \emph{d}) or \code{"unbiased"}

--- a/man/grouped_gghistostats.Rd
+++ b/man/grouped_gghistostats.Rd
@@ -120,7 +120,7 @@ argument can be \code{"biased"} (\code{"d"} for Cohen's \emph{d}) or \code{"unbi
 or Hedge's \emph{g} (Default: \code{TRUE}).}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{nboot}{Number of bootstrap samples for computing confidence interval
 for the effect size (Default: \code{100}).}

--- a/man/grouped_ggpiestats.Rd
+++ b/man/grouped_ggpiestats.Rd
@@ -138,7 +138,7 @@ hypothesis under the alternative, and corresponds to Gunel and Dickey's
 \item{caption}{The text for the plot caption.}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{bf.prior}{A numeric value between \code{0.5} and \code{2} (default \code{0.707}), the
 prior width to use in calculating Bayes Factors.}
@@ -185,9 +185,7 @@ override some aspects of the selected \code{ggtheme}.}
 \item{package}{Name of package from which the palette is desired as string
 or symbol.}
 
-\item{palette}{If a character string (e.g., \code{"Set1"}), will use that named
-palette. If a number, will index into the list of palettes of appropriate
-type. Default palette is \code{"Dark2"}.}
+\item{palette}{Name of palette as string or symbol.}
 
 \item{direction}{Either \code{1} or \code{-1}. If \code{-1} the palette will be reversed.}
 

--- a/man/grouped_ggscatterstats.Rd
+++ b/man/grouped_ggscatterstats.Rd
@@ -83,7 +83,7 @@ parametric/pearson's), \code{"np"} (nonparametric/spearman), \code{"r"} (robust)
 \code{"bf"} (for bayes factor), resp.}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{bf.prior}{A numeric value between \code{0.5} and \code{2} (default \code{0.707}), the
 prior width to use in calculating Bayes Factors.}

--- a/man/grouped_ggwithinstats.Rd
+++ b/man/grouped_ggwithinstats.Rd
@@ -154,7 +154,7 @@ should be displayed for each level of the grouping variable \code{x} (Default:
 (Default: \code{k = 2}).}
 
 \item{conf.level}{Scalar between 0 and 1. If unspecified, the defaults return
-\verb{95\%} lower and upper confidence intervals (\code{0.95}).}
+\code{95\%} lower and upper confidence intervals (\code{0.95}).}
 
 \item{nboot}{Number of bootstrap samples for computing confidence interval
 for the effect size (Default: \code{100}).}
@@ -260,9 +260,7 @@ override some aspects of the selected \code{ggtheme}.}
 \item{package}{Name of package from which the palette is desired as string
 or symbol.}
 
-\item{palette}{If a character string (e.g., \code{"Set1"}), will use that named
-palette. If a number, will index into the list of palettes of appropriate
-type. Default palette is \code{"Dark2"}.}
+\item{palette}{Name of palette as string or symbol.}
 
 \item{direction}{Either \code{1} or \code{-1}. If \code{-1} the palette will be reversed.}
 

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -22,7 +22,7 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{broomExtra}{\code{\link[broomExtra]{\%$\%}}, \code{\link[broomExtra]{\%<>\%}}, \code{\link[broomExtra]{\%>\%}}}
+  \item{broomExtra}{\code{\link[broomExtra]{\%<>\%}}, \code{\link[broomExtra]{\%>\%}}, \code{\link[broomExtra]{\%$\%}}}
 
   \item{groupedstats}{\code{\link[groupedstats]{lm_effsize_ci}}, \code{\link[groupedstats]{set_cwd}}, \code{\link[groupedstats]{signif_column}}, \code{\link[groupedstats]{specify_decimal_p}}}
 

--- a/tests/testthat/test-ggbarstats.R
+++ b/tests/testthat/test-ggbarstats.R
@@ -173,7 +173,7 @@ testthat::test_that(
     # checking layered data
     testthat::expect_identical(
       pb$data[[1]]$fill,
-      c("#F5CDB4", "#9A8822", "#F5CDB4", "#9A8822", "#F5CDB4")
+      c("#F5CDB4FF", "#9A8822FF", "#F5CDB4FF", "#9A8822FF", "#F5CDB4FF")
     )
     testthat::expect_identical(pb$plot$guides$fill$title, "Engine")
     testthat::expect_equal(pb$plot$theme$axis.text.x$angle, 45L)

--- a/tests/testthat/test-ggbetweenstats.R
+++ b/tests/testthat/test-ggbetweenstats.R
@@ -443,11 +443,11 @@ testthat::test_that(
     testthat::expect_identical(length(pb2$data), 4L)
     testthat::expect_identical(
       unique(pb1$data[[1]]$colour),
-      c("#1B9E77", "#D95F02")
+      c("#1B9E77FF", "#D95F02FF")
     )
     testthat::expect_identical(
       unique(pb2$data[[1]]$colour),
-      c("#899DA4", "#C93312")
+      c("#899DA4FF", "#C93312FF")
     )
     testthat::expect_identical(
       pb2$layout$panel_params[[1]]$x.labels,

--- a/tests/testthat/test-ggcoefstats.R
+++ b/tests/testthat/test-ggcoefstats.R
@@ -81,8 +81,8 @@ testthat::test_that(
       )
     )
     testthat::expect_identical(
-      pb$data[[4]]$colour,
-      c("#1B9E77", "#D95F02", "#7570B3", "#E7298A")
+      unclass(pb$data[[4]]$colour),
+      c("#1B9E77FF", "#D95F02FF", "#7570B3FF", "#E7298AFF")
     )
   }
 )
@@ -344,8 +344,8 @@ testthat::test_that(
       c("brainwt", "vore:brainwt", "vore")
     )
     testthat::expect_identical(
-      pb$data[[4]]$colour,
-      c("#FAD510", "#CB2314", "#273046")
+      unclass(pb$data[[4]]$colour),
+      c("#FAD510FF", "#CB2314FF", "#273046FF")
     )
   }
 )

--- a/tests/testthat/test-ggcorrmat.R
+++ b/tests/testthat/test-ggcorrmat.R
@@ -119,8 +119,8 @@ testthat::test_that(
     testthat::expect_equal(dat$signif[4], 1L)
     testthat::expect_equal(dat$signif[5], 0L)
     testthat::expect_identical(
-      p$plot_env$colors,
-      c("#1B9E77", "#D95F02", "#7570B3")
+      unclass(p$plot_env$colors),
+      c("#1B9E77FF", "#D95F02FF", "#7570B3FF")
     )
 
     # checking layers
@@ -341,8 +341,8 @@ testthat::test_that(
     testthat::expect_equal(dat$signif[10], 0L)
     testthat::expect_equal(dat$signif[11], 1L)
     testthat::expect_identical(
-      p$plot_env$colors,
-      c("#E1BD6D", "#EABE94", "#0B775E")
+      unclass(p$plot_env$colors),
+      c("#E1BD6DFF", "#EABE94FF", "#0B775EFF")
     )
     testthat::expect_identical(p_legend_title, ggplot2::expr(atop(atop(
       atop(scriptstyle(bold("sample size:")), italic(n)[min] ~

--- a/tests/testthat/test-ggpiestats.R
+++ b/tests/testthat/test-ggpiestats.R
@@ -97,7 +97,7 @@ testthat::test_that(
     testthat::expect_equal(dim(pb$data[[2]]), c(4L, 19L))
     testthat::expect_identical(
       pb$data[[1]]$fill,
-      c("#E7298A", "#7570B3", "#D95F02", "#1B9E77")
+      c("#E7298AFF", "#7570B3FF", "#D95F02FF", "#1B9E77FF")
     )
   }
 )
@@ -316,17 +316,17 @@ testthat::test_that(
     testthat::expect_identical(
       pb$data[[1]]$fill,
       c(
-        "#F5CDB4",
-        "#9A8822",
-        "#F5CDB4",
-        "#9A8822",
-        "#F5CDB4",
-        "#9A8822"
+        "#F5CDB4FF",
+        "#9A8822FF",
+        "#F5CDB4FF",
+        "#9A8822FF",
+        "#F5CDB4FF",
+        "#9A8822FF"
       )
     )
     testthat::expect_identical(
       pb1$data[[1]]$fill,
-      c("#7570B3", "#D95F02", "#1B9E77")
+      c("#7570B3FF", "#D95F02FF", "#1B9E77FF")
     )
 
     # test layout

--- a/tests/testthat/test-ggscatterstats.R
+++ b/tests/testthat/test-ggscatterstats.R
@@ -65,8 +65,8 @@ testthat::test_that(
     # checking intercepts
     testthat::expect_equal(pb$data[[3]]$xintercept, 10.43373, tolerance = 0.001)
     testthat::expect_equal(pb$data[[4]]$yintercept, 166.1363, tolerance = 0.001)
-    testthat::expect_equal(pb$data[[3]]$colour, "#A42820")
-    testthat::expect_equal(pb$data[[4]]$colour, "#5F5647")
+    testthat::expect_equal(unclass(pb$data[[3]]$colour), "#A42820FF")
+    testthat::expect_equal(unclass(pb$data[[4]]$colour), "#5F5647FF")
 
     # check labels
     testthat::expect_equal(p$plot_env$x_label_pos, 10.88401, tolerance = 0.002)

--- a/vignettes/web_only/ggdotplotstats.Rmd
+++ b/vignettes/web_only/ggdotplotstats.Rmd
@@ -57,8 +57,7 @@ df <- dplyr::filter(.data = ggplot2::mpg, cyl %in% c("4", "6"))
 
 # creating a vector of colors using `paletteer` package
 paletter_vector <- paletteer::paletteer_d(
-  package = "palettetown",
-  palette = "venusaur",
+  palette = "palettetown::venusaur",
   n = nlevels(as.factor(df$manufacturer)),
   type = "discrete"
 )


### PR DESCRIPTION
This PR will close #340.

I have 

- Changes functions to internally combine the `package` and `palette` argument to preserve the user experience.
- Manually added `package` and `palette` documentation since it can't be inherited from **paletteer**.
- Updated the text to reflect how **paletteer** returns colors with alpha values (#FFFFFFFF instead of #FFFFFF)