### PR TITLE
Allow for the addition of 95% CIs or standard errors around the pointwise estimates

### DIFF
--- a/R/DMdataviz2.R
+++ b/R/DMdataviz2.R
@@ -1,0 +1,4 @@
+####téléchargement des packages utiles
+install.packages("devtools")
+library(devtools)
+install_local("/chemin/vers/ton/package/ggstatsplot")

--- a/R/DMdataviz2.R
+++ b/R/DMdataviz2.R
@@ -1,4 +1,4 @@
 ####téléchargement des packages utiles
 install.packages("devtools")
 library(devtools)
-install_local("/chemin/vers/ton/package/ggstatsplot")
+install_local("~/work/ggstatsplot")

--- a/R/ggdotplotstats.R
+++ b/R/ggdotplotstats.R
@@ -47,30 +47,30 @@
 #' extract_stats(p)
 #' @export
 ggdotplotstats <- function(
-  data,
-  x,
-  y,
-  xlab = NULL,
-  ylab = NULL,
-  title = NULL,
-  subtitle = NULL,
-  caption = NULL,
-  type = "parametric",
-  test.value = 0,
-  bf.prior = 0.707,
-  bf.message = TRUE,
-  effsize.type = "g",
-  conf.level = 0.95,
-  tr = 0.2,
-  digits = 2L,
-  results.subtitle = TRUE,
-  point.args = list(color = "black", size = 3, shape = 16),
-  centrality.plotting = TRUE,
-  centrality.type = type,
-  centrality.line.args = list(color = "blue", linewidth = 1, linetype = "dashed"),
-  ggplot.component = NULL,
-  ggtheme = ggstatsplot::theme_ggstatsplot(),
-  ...
+    data,
+    x,
+    y,
+    xlab = NULL,
+    ylab = NULL,
+    title = NULL,
+    subtitle = NULL,
+    caption = NULL,
+    type = "parametric",
+    test.value = 0,
+    bf.prior = 0.707,
+    bf.message = TRUE,
+    effsize.type = "g",
+    conf.level = 0.95,
+    tr = 0.2,
+    digits = 2L,
+    results.subtitle = TRUE,
+    point.args = list(color = "black", size = 3, shape = 16),
+    centrality.plotting = TRUE,
+    centrality.type = type,
+    centrality.line.args = list(color = "blue", linewidth = 1, linetype = "dashed"),
+    ggplot.component = NULL,
+    ggtheme = ggstatsplot::theme_ggstatsplot(),
+    ...
 ) {
   # data -----------------------------------
 
@@ -103,13 +103,16 @@ ggdotplotstats <- function(
       tr = tr,
       bf.prior = bf.prior
     )
-
-    subtitle_df <- .eval_f(one_sample_test, !!!.f.args, type = type)
-    subtitle <- .extract_expression(subtitle_df)
+    #On utilise "ggstatsplot:::" pour accéder à la fonction interne
+    #Attention l'implémentation peut changer dans les futures mises à jour du package
+    #peut être à modifier plus tard.
+    subtitle_df <- ggstatsplot:::.eval_f(one_sample_test, !!!.f.args, type = type)
+    subtitle <- ggstatsplot:::.extract_expression(subtitle_df)
 
     if (type == "parametric" && bf.message) {
-      caption_df <- .eval_f(one_sample_test, !!!.f.args, type = "bayes")
-      caption <- .extract_expression(caption_df)
+      #Idem pour "ggstatsplot:::"
+      caption_df <- ggstatsplot:::.eval_f(one_sample_test, !!!.f.args, type = "bayes")
+      caption <- ggstatsplot:::.extract_expression(caption_df)
     }
   }
 
@@ -131,7 +134,8 @@ ggdotplotstats <- function(
   # centrality plotting -------------------------------------
 
   if (isTRUE(centrality.plotting)) {
-    plot_dot <- .histo_labeller(
+    #Idem pour "ggstatsplot:::"
+    plot_dot <- ggstatsplot:::.histo_labeller(
       plot_dot,
       x = pull(data, {{ x }}),
       type = stats_type_switch(centrality.type),
@@ -195,11 +199,11 @@ ggdotplotstats <- function(
 #' )
 #' @export
 grouped_ggdotplotstats <- function(
-  data,
-  ...,
-  grouping.var,
-  plotgrid.args = list(),
-  annotation.args = list()
+    data,
+    ...,
+    grouping.var,
+    plotgrid.args = list(),
+    annotation.args = list()
 ) {
   .grouped_list(data, {{ grouping.var }}) %>%
     purrr::pmap(.f = ggdotplotstats, ...) %>%

--- a/R/ggdotplotstats.R
+++ b/R/ggdotplotstats.R
@@ -82,7 +82,11 @@ ggdotplotstats <- function(
     select({{ x }}, {{ y }}) %>%
     tidyr::drop_na() %>%
     mutate({{ y }} := droplevels(as.factor({{ y }}))) %>%
-    summarise({{ x }} := mean({{ x }}), .by = {{ y }}) %>%
+    # modification à tester
+    summarise({{ x }} := mean({{ x }}),
+              lower_ci = mean_cl_normal({{ x }})$ymin,
+              upper_ci = mean_cl_normal({{ x }})$ymax,
+              .by = {{ y }}) %>%
     # rank ordering the data
     arrange({{ x }}) %>%
     mutate(
@@ -157,6 +161,11 @@ ggdotplotstats <- function(
     ) +
     ggtheme +
     ggplot.component
+  # modification à tester
+  plot_dot <- plot_dot +
+    geom_errorbar(aes(ymin = lower_ci, ymax = upper_ci), width = 0.2, color = "red")
+
+
 }
 
 

--- a/R/ggdotplotstats.R
+++ b/R/ggdotplotstats.R
@@ -6,18 +6,45 @@
 #' A dot chart (as described by William S. Cleveland) with statistical details
 #' from one-sample test.
 #'
+#' @section Summary of graphics:
+#'
+#' ```{r child="man/rmd-fragments/ggdotplotstats_graphics.Rmd"}
+#' ```
+#'
 #' @param ... Currently ignored.
 #' @param y Label or grouping variable.
 #' @inheritParams gghistostats
 #' @inheritParams ggcoefstats
 #' @inheritParams ggbetweenstats
 #'
-#' @param conf.plotting Logical; if TRUE, adds 95% confidence intervals around the mean points.
-#' @param conf.level Numeric; the confidence level for the intervals (default is 0.95).
-#' @param conf.plot.args List; additional arguments passed to `ggdist::stat_pointinterval()` for customizing the confidence intervals.
+#' @inheritSection statsExpressions::one_sample_test One-sample tests
 #'
-#' @seealso \code{\link{grouped_gghistostats}}, \code{\link{ggdotplotstats}},
-#'  \code{\link{gghistostats}}
+#' @seealso \code{\link{grouped_gghistostats}}, \code{\link{gghistostats}},
+#'  \code{\link{grouped_ggdotplotstats}}
+#'
+#' @autoglobal
+#'
+#' @details For details, see:
+#' <https://indrajeetpatil.github.io/ggstatsplot/articles/web_only/ggdotplotstats.html>
+#'
+#' @examplesIf identical(Sys.getenv("NOT_CRAN"), "true")
+#' # for reproducibility
+#' set.seed(123)
+#'
+#' # creating a plot
+#' p <- ggdotplotstats(
+#'   data = ggplot2::mpg,
+#'   x = cty,
+#'   y = manufacturer,
+#'   title = "Fuel economy data",
+#'   xlab = "city miles per gallon"
+#' )
+#'
+#' # looking at the plot
+#' p
+#'
+#' # extracting details from statistical tests
+#' extract_stats(p)
 #' @export
 ggdotplotstats <- function(
     data,


### PR DESCRIPTION
With @sidocleux , in our first modifications, the confidence intervals were not visible on the graph. This may be due to the high concentration of data around the mean, which reduces the standard error and therefore the width of the confidence intervals. 
We therefore chose to calculate the confidence intervals manually. We used the mean, the standard error and a normal approximation (qnorm()) to determine the lower and upper bounds of the confidence interval. Then, to display them on the graph, we used geom_errorbarh() (which displays the horizontal error bars in red). Other solutions, such as ggdist with stat_pointinterval() or stat_eye(), could have been used, but they require more configuration (choice of distribution, additional parameters).

We have also encountered a problem since version 3.4.0 of ggplot2: the size argument should no longer be used to define the thickness of lines (geom_errorbarh(), geom_line(), etc.). Instead, we use linewidth.

Here is the graph we obtained : 
<img width="812" alt="plot_zoom_png (1)" src="https://github.com/user-attachments/assets/09bf3618-b820-4676-a734-0c55157ad39f" />