### PR TITLE
Custom Scales and Font Size for histograms in ggscatterstats - Issue #898

### DIFF
--- a/R/ggscatterstats.R
+++ b/R/ggscatterstats.R
@@ -96,6 +96,8 @@ ggscatterstats <- function(
   smooth.line.args = list(linewidth = 1.5, color = "blue", method = "lm", formula = y ~ x),
   xsidehistogram.args = list(fill = "#009E73", color = "black", na.rm = TRUE),
   ysidehistogram.args = list(fill = "#D55E00", color = "black", na.rm = TRUE),
+  xsidehistogram.scale = NULL,
+  ysidehistogram.scale = NULL,
   xlab = NULL,
   ylab = NULL,
   title = NULL,
@@ -178,15 +180,20 @@ ggscatterstats <- function(
 
   # marginal  ---------------------------------------------
 
-  if (isTRUE(marginal)) {
+  if (isTRUE(marginal)){
     plot_scatter <- plot_scatter +
       exec(ggside::geom_xsidehistogram, mapping = aes(y = after_stat(count)), !!!xsidehistogram.args) +
-      exec(ggside::geom_ysidehistogram, mapping = aes(x = after_stat(count)), !!!ysidehistogram.args) +
-      ggside::scale_ysidex_continuous() +
-      ggside::scale_xsidey_continuous()
+      exec(ggside::geom_ysidehistogram, mapping = aes(x = after_stat(count)), !!!ysidehistogram.args)
+    
+    # Apply scaling if specified
+    if (!is.null(xsidehistogram.scale)) {
+      plot_scatter <- plot_scatter + ggside::scale_xsidey_continuous(limits = xsidehistogram.scale)
+    }
+    if (!is.null(ysidehistogram.scale)) {
+      plot_scatter <- plot_scatter + ggside::scale_ysidex_continuous(limits = ysidehistogram.scale)
+    }
+    plot_scatter
   }
-
-  plot_scatter
 }
 
 
@@ -257,8 +264,8 @@ grouped_ggscatterstats <- function(
   grouping.var,
   plotgrid.args = list(),
   annotation.args = list()
-) {
+){
   .grouped_list(data, {{ grouping.var }}) %>%
     purrr::pmap(.f = ggscatterstats, ...) %>%
     combine_plots(plotgrid.args, annotation.args)
-}
+  }

--- a/R/ggscatterstats.R
+++ b/R/ggscatterstats.R
@@ -185,7 +185,7 @@ ggscatterstats <- function(
     plot_scatter <- plot_scatter +
       exec(ggside::geom_xsidehistogram, mapping = aes(y = after_stat(count)), !!!xsidehistogram.args) +
       exec(ggside::geom_ysidehistogram, mapping = aes(x = after_stat(count)), !!!ysidehistogram.args)
-    
+
     # Apply scaling if specified
     if (!is.null(xsidehistogram.scale)) {
       plot_scatter <- plot_scatter + ggside::scale_xsidey_continuous(limits = xsidehistogram.scale)
@@ -193,9 +193,8 @@ ggscatterstats <- function(
     if (!is.null(ysidehistogram.scale)) {
       plot_scatter <- plot_scatter + ggside::scale_ysidex_continuous(limits = ysidehistogram.scale)
     }
-    plot_scatter
   }
-<<<<<<< HEAD
+
   plot_scatter <- plot_scatter +
     theme(
       ggside.axis.text.x = element_text(size = marginal_axis_text_size),
@@ -203,8 +202,7 @@ ggscatterstats <- function(
     )
 
   plot_scatter
-=======
->>>>>>> leo
+
 }
 
 

--- a/R/ggscatterstats.R
+++ b/R/ggscatterstats.R
@@ -79,7 +79,7 @@ ggscatterstats <- function(
   data,
   x,
   y,
-  axis_text_size = 10,
+  marginal_axis_text_size = 10,
   type = "parametric",
   conf.level = 0.95,
   bf.prior = 0.707,
@@ -188,10 +188,8 @@ ggscatterstats <- function(
   }
   plot_scatter <- plot_scatter +
     theme(
-      axis.text.x = element_text(size = axis_text_size),
-      axis.text.y = element_text(size = axis_text_size),
-      ggside.axis.text.x = element_text(size = axis_text_size),
-      ggside.axis.text.y = element_text(size = axis_text_size)
+      ggside.axis.text.x = element_text(size = marginal_axis_text_size),
+      ggside.axis.text.y = element_text(size = marginal_axis_text_size)
     )
 
   plot_scatter

--- a/R/ggscatterstats.R
+++ b/R/ggscatterstats.R
@@ -79,6 +79,7 @@ ggscatterstats <- function(
   data,
   x,
   y,
+  axis_text_size = 10,
   type = "parametric",
   conf.level = 0.95,
   bf.prior = 0.707,
@@ -185,6 +186,13 @@ ggscatterstats <- function(
       ggside::scale_ysidex_continuous() +
       ggside::scale_xsidey_continuous()
   }
+  plot_scatter <- plot_scatter +
+    theme(
+      axis.text.x = element_text(size = axis_text_size),
+      axis.text.y = element_text(size = axis_text_size),
+      ggside.axis.text.x = element_text(size = axis_text_size),
+      ggside.axis.text.y = element_text(size = axis_text_size)
+    )
 
   plot_scatter
 }


### PR DESCRIPTION


Hello !

We hope you're doing well!

We have implemented a set of new features for `ggscatterstats` based on the recent issue regarding custom scales and font size adjustments. Specifically, we’ve added the following parameters:

- **`xsidehistogram.scale`**: To set a custom scale for the histogram on the x-axis.
- **`ysidehistogram.scale`**: To set a custom scale for the histogram on the y-axis.
- **`marginal_axis_text_size`**: To adjust the font size of the numbers on the marginal axes.

For example, the following code demonstrates how these parameters can be used:

```r
ggscatterstats(
  data = mtcars,
  x = wt,
  y = mpg,
  xsidehistogram.scale = c(0, 200),
  ysidehistogram.scale = c(0, 10),
  marginal_axis_text_size = 5
)
