### PR TITLE
refactor: extract common plotting logic from ggbetweenstats and ggwithinstats

### DIFF
--- a/R/ggbetweenstats-helpers.R
+++ b/R/ggbetweenstats-helpers.R
@@ -1,3 +1,166 @@
+#' @title Compute subtitle and caption for box/violin plots
+#' @name .bw_subtitle_caption
+#'
+#' @description
+#'
+#' Shared helper for `ggbetweenstats()` and `ggwithinstats()` that runs the
+#' appropriate statistical test and optionally computes a Bayes Factor caption.
+#'
+#' @param test Character: `"t"` or `"anova"`.
+#' @param type Character: statistical test type (e.g. `"parametric"`).
+#' @param bf.message Logical: include Bayes Factor caption?
+#' @param .f.args A named list of arguments forwarded to the test function.
+#'
+#' @return A list with elements `subtitle` and `caption`.
+#'
+#' @autoglobal
+#' @noRd
+.bw_subtitle_caption <- function(test, type, bf.message, .f.args) {
+  .f <- .f_switch(test)
+  subtitle_df <- .eval_f(.f, !!!.f.args, type = type)
+  subtitle <- .extract_expression(subtitle_df)
+  caption_df <- NULL
+  caption <- NULL
+
+  if (type == "parametric" && bf.message) {
+    caption_df <- .eval_f(.f, !!!.f.args, type = "bayes")
+    caption <- .extract_expression(caption_df)
+  }
+
+  list(
+    subtitle = subtitle,
+    caption = caption,
+    subtitle_df = subtitle_df,
+    caption_df = caption_df
+  )
+}
+
+
+#' @title Decorate a box/violin comparison plot
+#' @name .bw_decorate
+#'
+#' @description
+#'
+#' Adds centrality labels, sample-size x-axis labels, pairwise-comparison
+#' annotations (ggsignif), and final aesthetic theming shared by
+#' `ggbetweenstats()` and `ggwithinstats()`.
+#'
+#' @param plot A `ggplot` object to decorate.
+#' @param data Data frame used for plotting.
+#' @param pairwise_args A named list of extra arguments forwarded to
+#'   [pairwise_comparisons()], typically containing `data`, `paired`,
+#'   `p.adjust.method`, and optionally `var.equal` or `subject.id`.
+#' @inheritParams ggbetweenstats
+#' @inheritParams ggwithinstats
+#'
+#' @return A decorated `ggplot` object.
+#'
+#' @autoglobal
+#' @noRd
+.bw_decorate <- function(
+  plot,
+  data,
+  x,
+  y,
+  type,
+  test,
+  centrality.plotting,
+  centrality.type,
+  digits,
+  tr,
+  centrality.point.args,
+  centrality.label.args,
+  pairwise.display,
+  pairwise.alpha,
+  pairwise_args,
+  ggsignif.args,
+  xlab,
+  ylab,
+  title,
+  subtitle,
+  caption,
+  ggtheme,
+  palette,
+  ggplot.component,
+  centrality.path = FALSE,
+  centrality.path.args = list()
+) {
+  x <- ensym(x)
+  y <- ensym(y)
+
+  # centrality tagging
+  if (isTRUE(centrality.plotting)) {
+    plot <- suppressWarnings(.centrality_ggrepel(
+      plot = plot,
+      data = data,
+      x = !!x,
+      y = !!y,
+      digits = digits,
+      type = stats_type_switch(centrality.type),
+      tr = tr,
+      centrality.path = centrality.path,
+      centrality.path.args = centrality.path.args,
+      centrality.point.args = centrality.point.args,
+      centrality.label.args = centrality.label.args
+    ))
+  }
+
+  # sample size labels on x-axis
+  centrality_df <- suppressWarnings(centrality_description(
+    data,
+    !!x,
+    !!y
+  ))
+  plot <- plot +
+    scale_x_discrete(labels = unique(centrality_df$n.expression))
+
+  # ggsignif labels
+  seclabel <- NULL
+
+  if (pairwise.display != "none" && test == "anova") {
+    pw_args <- c(
+      list(x = x, y = y, type = type, tr = tr, digits = digits),
+      pairwise_args
+    )
+    mpc_df <- suppressWarnings(inject(pairwise_comparisons(!!!pw_args)))
+
+    assign("mpc_df", mpc_df, envir = plot$plot_env)
+
+    plot <- .ggsignif_adder(
+      plot = plot,
+      mpc_df = mpc_df,
+      data = data,
+      x = !!x,
+      y = !!y,
+      pairwise.display = pairwise.display,
+      pairwise.alpha = pairwise.alpha,
+      ggsignif.args = ggsignif.args
+    )
+
+    seclabel <- .pairwise_seclabel(
+      test.description = unique(mpc_df$test),
+      pairwise.display = ifelse(type == "bayes", "all", pairwise.display),
+      pairwise.alpha = pairwise.alpha
+    )
+  }
+
+  # annotations
+  .aesthetic_addon(
+    plot = plot,
+    x = pull(data, !!x),
+    xlab = xlab,
+    ylab = ylab,
+    title = title,
+    subtitle = subtitle,
+    caption = caption,
+    seclabel = seclabel,
+    ggtheme = ggtheme,
+    palette = palette,
+    ggplot.component = ggplot.component
+  )
+}
+
+
 #' @title Adding labels for mean values.
 #' @name .centrality_ggrepel
 #'

--- a/R/ggbetweenstats.R
+++ b/R/ggbetweenstats.R
@@ -238,14 +238,11 @@ ggbetweenstats <- function(
       .f.args$alternative <- alternative
     }
 
-    .f <- .f_switch(test)
-    subtitle_df <- .eval_f(.f, !!!.f.args, type = type)
-    subtitle <- .extract_expression(subtitle_df)
-
-    if (type == "parametric" && bf.message) {
-      caption_df <- .eval_f(.f, !!!.f.args, type = "bayes")
-      caption <- .extract_expression(caption_df)
-    }
+    sc <- .bw_subtitle_caption(test, type, bf.message, .f.args)
+    subtitle <- sc$subtitle
+    caption <- sc$caption
+    subtitle_df <- sc$subtitle_df
+    caption_df <- sc$caption_df
   }
 
   # plot -----------------------------------
@@ -255,79 +252,35 @@ ggbetweenstats <- function(
     exec(geom_boxplot, !!!boxplot.args, outlier.shape = NA) +
     exec(geom_violin, !!!violin.args)
 
-  # centrality tagging -------------------------------------
+  # decorate and return -----------------------------------
 
-  if (isTRUE(centrality.plotting)) {
-    plot_comparison <- suppressWarnings(.centrality_ggrepel(
-      plot = plot_comparison,
+  .bw_decorate(
+    plot = plot_comparison,
+    data = data,
+    x = {{ x }},
+    y = {{ y }},
+    type = type,
+    test = test,
+    centrality.plotting = centrality.plotting,
+    centrality.type = centrality.type,
+    digits = digits,
+    tr = tr,
+    centrality.point.args = centrality.point.args,
+    centrality.label.args = centrality.label.args,
+    pairwise.display = pairwise.display,
+    pairwise.alpha = pairwise.alpha,
+    pairwise_args = list(
       data = data,
-      x = {{ x }},
-      y = {{ y }},
-      digits = digits,
-      type = stats_type_switch(centrality.type),
-      tr = tr,
-      centrality.point.args = centrality.point.args,
-      centrality.label.args = centrality.label.args
-    ))
-  }
-
-  # sample size labels on x-axis
-  centrality_df <- suppressWarnings(centrality_description(
-    data,
-    {{ x }},
-    {{ y }}
-  ))
-  plot_comparison <- plot_comparison +
-    scale_x_discrete(labels = unique(centrality_df$n.expression))
-
-  # ggsignif labels -------------------------------------
-
-  seclabel <- NULL
-
-  if (pairwise.display != "none" && test == "anova") {
-    mpc_df <- suppressWarnings(pairwise_comparisons(
-      data = data,
-      x = {{ x }},
-      y = {{ y }},
-      type = type,
-      tr = tr,
       paired = FALSE,
       var.equal = var.equal,
-      p.adjust.method = p.adjust.method,
-      digits = digits
-    ))
-
-    # adding the layer for pairwise comparisons
-    plot_comparison <- .ggsignif_adder(
-      plot = plot_comparison,
-      mpc_df = mpc_df,
-      data = data,
-      x = {{ x }},
-      y = {{ y }},
-      pairwise.display = pairwise.display,
-      pairwise.alpha = pairwise.alpha,
-      ggsignif.args = ggsignif.args
-    )
-
-    # secondary label axis to give pairwise comparisons test details
-    seclabel <- .pairwise_seclabel(
-      test.description = unique(mpc_df$test),
-      pairwise.display = ifelse(type == "bayes", "all", pairwise.display),
-      pairwise.alpha = pairwise.alpha
-    )
-  }
-
-  # annotations ------------------------
-
-  .aesthetic_addon(
-    plot = plot_comparison,
-    x = pull(data, {{ x }}),
+      p.adjust.method = p.adjust.method
+    ),
+    ggsignif.args = ggsignif.args,
     xlab = xlab %||% as_name(x),
     ylab = ylab %||% as_name(y),
     title = title,
     subtitle = subtitle,
     caption = caption,
-    seclabel = seclabel,
     ggtheme = ggtheme,
     palette = palette,
     ggplot.component = ggplot.component

--- a/R/ggwithinstats.R
+++ b/R/ggwithinstats.R
@@ -211,18 +211,11 @@ ggwithinstats <- function(
       .f.args$alternative <- alternative
     }
 
-    # styler: off
-    .f <- .f_switch(test)
-    subtitle_df <- .eval_f(.f, !!!.f.args, type = type)
-    subtitle <- .extract_expression(subtitle_df)
-    # styler: on
-
-    if (type == "parametric" && bf.message) {
-      # styler: off
-      caption_df <- .eval_f(.f, !!!.f.args, type = "bayes")
-      caption <- .extract_expression(caption_df)
-      # styler: on
-    }
+    sc <- .bw_subtitle_caption(test, type, bf.message, .f.args)
+    subtitle <- sc$subtitle
+    caption <- sc$caption
+    subtitle_df <- sc$subtitle_df
+    caption_df <- sc$caption_df
   }
 
   # plot -------------------------------------------
@@ -248,82 +241,37 @@ ggwithinstats <- function(
     plot_comparison <- plot_comparison + exec(geom_path, !!!point.path.args)
   }
 
-  # centrality tagging -------------------------------------
+  # decorate and return -------------------------
 
-  if (isTRUE(centrality.plotting)) {
-    plot_comparison <- suppressWarnings(.centrality_ggrepel(
-      plot = plot_comparison,
-      data = data,
-      x = {{ x }},
-      y = {{ y }},
-      digits = digits,
-      type = stats_type_switch(centrality.type),
-      tr = tr,
-      centrality.path = centrality.path,
-      centrality.path.args = centrality.path.args,
-      centrality.point.args = centrality.point.args,
-      centrality.label.args = centrality.label.args
-    ))
-  }
-
-  # sample size labels on x-axis
-  centrality_df <- suppressWarnings(centrality_description(
-    data,
-    {{ x }},
-    {{ y }}
-  ))
-  plot_comparison <- plot_comparison +
-    scale_x_discrete(labels = unique(centrality_df$n.expression))
-
-  # ggsignif labels -------------------------------------
-
-  # initialize
-  seclabel <- NULL
-
-  if (pairwise.display != "none" && test == "anova") {
-    mpc_df <- suppressWarnings(pairwise_comparisons(
-      data = stats_data,
-      x = {{ x }},
-      y = {{ y }},
-      subject.id = subject.id,
-      type = type,
-      tr = tr,
-      paired = TRUE,
-      p.adjust.method = p.adjust.method,
-      digits = digits
-    ))
-
-    # adding the layer for pairwise comparisons
-    plot_comparison <- .ggsignif_adder(
-      plot = plot_comparison,
-      mpc_df = mpc_df,
-      data = data,
-      x = {{ x }},
-      y = {{ y }},
-      pairwise.display = pairwise.display,
-      pairwise.alpha = pairwise.alpha,
-      ggsignif.args = ggsignif.args
-    )
-
-    # secondary label axis to give pairwise comparisons test details
-    seclabel <- .pairwise_seclabel(
-      test.description = unique(mpc_df$test),
-      pairwise.display = ifelse(type == "bayes", "all", pairwise.display),
-      pairwise.alpha = pairwise.alpha
-    )
-  }
-
-  # annotations -------------------------
-
-  .aesthetic_addon(
+  .bw_decorate(
     plot = plot_comparison,
-    x = pull(data, {{ x }}),
+    data = data,
+    x = {{ x }},
+    y = {{ y }},
+    type = type,
+    test = test,
+    centrality.plotting = centrality.plotting,
+    centrality.type = centrality.type,
+    digits = digits,
+    tr = tr,
+    centrality.point.args = centrality.point.args,
+    centrality.label.args = centrality.label.args,
+    centrality.path = centrality.path,
+    centrality.path.args = centrality.path.args,
+    pairwise.display = pairwise.display,
+    pairwise.alpha = pairwise.alpha,
+    pairwise_args = list(
+      data = stats_data,
+      paired = TRUE,
+      subject.id = subject.id,
+      p.adjust.method = p.adjust.method
+    ),
+    ggsignif.args = ggsignif.args,
     xlab = xlab %||% as_name(x),
     ylab = ylab %||% as_name(y),
     title = title,
     subtitle = subtitle,
     caption = caption,
-    seclabel = seclabel,
     ggtheme = ggtheme,
     palette = palette,
     ggplot.component = ggplot.component


### PR DESCRIPTION
## Summary

Addresses the first pair (ggbetweenstats / ggwithinstats) from #764.

- Extracts two shared helper functions into `R/ggbetweenstats-helpers.R`:
  - **`.bw_subtitle_caption()`**: runs the statistical test (two-sample or one-way ANOVA) and optionally computes a Bayes Factor caption — previously duplicated in both functions
  - **`.bw_decorate()`**: adds centrality labels, sample-size x-axis labels, pairwise comparison annotations (ggsignif), and final aesthetic theming — previously ~55 duplicated lines in each function
- Refactors `ggbetweenstats()` and `ggwithinstats()` to use these helpers, reducing each function by ~50 lines while preserving identical behavior
- Preserves `extract_stats()` / `extract_subtitle()` / `extract_caption()` compatibility by ensuring `subtitle_df`, `caption_df`, and `mpc_df` remain in the plot's environment

## Test plan

- [x] All 135 passing tests remain passing (57 pre-existing vdiffr snapshot failures unchanged)
- [x] No new lint warnings (`lintr::lint_package()`)
- [x] No formatting issues (`air format --check`)
- [x] `extract_subtitle()` and `extract_stats()` work correctly on refactored functions
- [x] No unit tests were modified