### PR TITLE
refactor: extract common plotting logic from ggpiestats and ggbarstats

### DIFF
--- a/R/ggbarstats.R
+++ b/R/ggbarstats.R
@@ -93,7 +93,12 @@ ggbarstats <- function(
   y <- if (!quo_is_null(enquo(y))) ensym(y)
   type <- stats_type_switch(type)
 
-  prep <- .pie_bar_data_prep(data, {{ x }}, {{ y }}, {{ counts }})
+  prep <- .pie_bar_data_prep(
+    data = data,
+    x = {{ x }},
+    y = {{ y }},
+    counts = {{ counts }}
+  )
   data <- prep$data
   test <- prep$test
   x_levels <- prep$x_levels
@@ -112,23 +117,23 @@ ggbarstats <- function(
 
   if (results.subtitle) {
     stats_output <- .pie_bar_subtitle_caption(
-      data,
-      {{ x }},
-      {{ y }},
-      type,
-      paired,
-      bf.message,
-      caption,
-      alternative,
-      conf.level,
-      digits,
-      ratio,
-      sampling.plan,
-      fixed.margin,
-      prior.concentration,
-      x_levels,
-      y_levels,
-      p.adjust.method
+      data = data,
+      x = {{ x }},
+      y = {{ y }},
+      type = type,
+      paired = paired,
+      bf.message = bf.message,
+      caption = caption,
+      alternative = alternative,
+      conf.level = conf.level,
+      digits = digits,
+      ratio = ratio,
+      sampling.plan = sampling.plan,
+      fixed.margin = fixed.margin,
+      prior.concentration = prior.concentration,
+      x_levels = x_levels,
+      y_levels = y_levels,
+      p.adjust.method = p.adjust.method
     )
     subtitle <- stats_output$subtitle
     caption <- stats_output$caption

--- a/R/ggbarstats.R
+++ b/R/ggbarstats.R
@@ -111,13 +111,14 @@ ggbarstats <- function(
   # statistical analysis ------------------------------------------
 
   if (results.subtitle) {
-    sc <- .pie_bar_subtitle_caption(
+    stats_output <- .pie_bar_subtitle_caption(
       data,
       {{ x }},
       {{ y }},
       type,
       paired,
       bf.message,
+      caption,
       alternative,
       conf.level,
       digits,
@@ -129,11 +130,11 @@ ggbarstats <- function(
       y_levels,
       p.adjust.method
     )
-    subtitle <- sc$subtitle
-    caption <- sc$caption
-    subtitle_df <- sc$subtitle_df
-    caption_df <- sc$caption_df
-    mpc_df <- sc$mpc_df
+    subtitle <- stats_output$subtitle
+    caption <- stats_output$caption
+    subtitle_df <- stats_output$subtitle_df
+    caption_df <- stats_output$caption_df
+    mpc_df <- stats_output$mpc_df
   }
 
   # plot ------------------------------------------

--- a/R/ggbarstats.R
+++ b/R/ggbarstats.R
@@ -112,10 +112,22 @@ ggbarstats <- function(
 
   if (results.subtitle) {
     sc <- .pie_bar_subtitle_caption(
-      data, {{ x }}, {{ y }}, type, paired, bf.message,
-      alternative, conf.level, digits, ratio,
-      sampling.plan, fixed.margin, prior.concentration,
-      x_levels, y_levels, p.adjust.method
+      data,
+      {{ x }},
+      {{ y }},
+      type,
+      paired,
+      bf.message,
+      alternative,
+      conf.level,
+      digits,
+      ratio,
+      sampling.plan,
+      fixed.margin,
+      prior.concentration,
+      x_levels,
+      y_levels,
+      p.adjust.method
     )
     subtitle <- sc$subtitle
     caption <- sc$caption

--- a/R/ggbarstats.R
+++ b/R/ggbarstats.R
@@ -89,29 +89,16 @@ ggbarstats <- function(
 
   # data frame ------------------------------------------
 
-  # ensure the variables work quoted or unquoted
   x <- ensym(x)
   y <- if (!quo_is_null(enquo(y))) ensym(y)
   type <- stats_type_switch(type)
 
-  # one-way or two-way table?
-  test <- ifelse(quo_is_null(enquo(y)), "one.way", "two.way")
+  prep <- .pie_bar_data_prep(data, {{ x }}, {{ y }}, {{ counts }})
+  data <- prep$data
+  test <- prep$test
+  x_levels <- prep$x_levels
+  y_levels <- prep$y_levels
 
-  data %<>%
-    select({{ x }}, {{ y }}, .counts = {{ counts }}) %>%
-    tidyr::drop_na()
-
-  # untable the data frame based on the count for each observation
-  if (".counts" %in% names(data)) {
-    data %<>% tidyr::uncount(weights = .counts)
-  }
-
-  # x and y need to be a factor
-  data %<>% mutate(across(.cols = everything(), .fns = ~ as.factor(.x)))
-  x_levels <- nlevels(pull(data, {{ x }}))
-  y_levels <- ifelse(test == "one.way", 0L, nlevels(pull(data, {{ y }})))
-
-  # one-way table not supported in `BayesFactor` ATM (richarddmorey/BayesFactor#159)
   # nocov start
   if (test == "two.way" && y_levels == 1L) {
     c(bf.message, proportion.test) %<-% c(FALSE, FALSE)
@@ -124,42 +111,17 @@ ggbarstats <- function(
   # statistical analysis ------------------------------------------
 
   if (results.subtitle) {
-    .f.args <- list(
-      data = data,
-      x = {{ x }},
-      y = {{ y }},
-      alternative = alternative,
-      conf.level = conf.level,
-      digits = digits,
-      paired = paired,
-      ratio = ratio,
-      sampling.plan = sampling.plan,
-      fixed.margin = fixed.margin,
-      prior.concentration = prior.concentration
+    sc <- .pie_bar_subtitle_caption(
+      data, {{ x }}, {{ y }}, type, paired, bf.message,
+      alternative, conf.level, digits, ratio,
+      sampling.plan, fixed.margin, prior.concentration,
+      x_levels, y_levels, p.adjust.method
     )
-
-    subtitle_df <- .eval_f(contingency_table, !!!.f.args, type = type)
-    subtitle <- .extract_expression(subtitle_df)
-
-    # Bayes Factor caption
-    if (type != "bayes" && bf.message && isFALSE(paired)) {
-      caption_df <- .eval_f(contingency_table, !!!.f.args, type = "bayes")
-      caption <- .extract_expression(caption_df)
-    }
-
-    # pairwise comparisons
-    mpc_df <- .pairwise_contingency(
-      data,
-      {{ x }},
-      {{ y }},
-      x_levels,
-      y_levels,
-      paired,
-      digits,
-      conf.level,
-      alternative,
-      p.adjust.method
-    )
+    subtitle <- sc$subtitle
+    caption <- sc$caption
+    subtitle_df <- sc$subtitle_df
+    caption_df <- sc$caption_df
+    mpc_df <- sc$mpc_df
   }
 
   # plot ------------------------------------------

--- a/R/ggbetweenstats.R
+++ b/R/ggbetweenstats.R
@@ -238,11 +238,16 @@ ggbetweenstats <- function(
       .f.args$alternative <- alternative
     }
 
-    sc <- .bw_subtitle_caption(test, type, bf.message, .f.args)
-    subtitle <- sc$subtitle
-    caption <- sc$caption
-    subtitle_df <- sc$subtitle_df
-    caption_df <- sc$caption_df
+    stats_output <- .bw_subtitle_caption(
+      test = test,
+      type = type,
+      bf.message = bf.message,
+      .f.args = .f.args
+    )
+    subtitle <- stats_output$subtitle
+    caption <- stats_output$caption
+    subtitle_df <- stats_output$subtitle_df
+    caption_df <- stats_output$caption_df
   }
 
   # plot -----------------------------------

--- a/R/ggpiestats-ggbarstats-helpers.R
+++ b/R/ggpiestats-ggbarstats-helpers.R
@@ -55,6 +55,7 @@
   type,
   paired,
   bf.message,
+  caption,
   alternative,
   conf.level,
   digits,
@@ -83,7 +84,6 @@
   subtitle_df <- .eval_f(contingency_table, !!!.f.args, type = type)
   subtitle <- .extract_expression(subtitle_df)
   caption_df <- NULL
-  caption <- NULL
 
   if (type != "bayes" && bf.message && isFALSE(paired)) {
     caption_df <- .eval_f(contingency_table, !!!.f.args, type = "bayes")

--- a/R/ggpiestats-ggbarstats-helpers.R
+++ b/R/ggpiestats-ggbarstats-helpers.R
@@ -1,3 +1,118 @@
+#' @title Prepare data for pie/bar chart functions
+#' @name .pie_bar_data_prep
+#'
+#' @description
+#'
+#' Shared data-preparation step for `ggpiestats()` and `ggbarstats()`:
+#' selects relevant columns, drops missing values, untables counts, converts
+#' to factors, and computes the number of levels for each variable.
+#'
+#' @inheritParams ggpiestats
+#'
+#' @return A named list with elements `data`, `test`, `x_levels`, `y_levels`.
+#'
+#' @autoglobal
+#' @noRd
+.pie_bar_data_prep <- function(data, x, y, counts) {
+  data %<>%
+    select({{ x }}, {{ y }}, .counts = {{ counts }}) %>%
+    tidyr::drop_na()
+
+  if (".counts" %in% names(data)) {
+    data %<>% tidyr::uncount(weights = .counts)
+  }
+
+  data %<>% mutate(across(.cols = everything(), .fns = ~ as.factor(.x)))
+
+  test <- ifelse(quo_is_null(enquo(y)), "one.way", "two.way")
+  x_levels <- nlevels(pull(data, {{ x }}))
+  y_levels <- ifelse(test == "one.way", 0L, nlevels(pull(data, {{ y }})))
+
+  list(data = data, test = test, x_levels = x_levels, y_levels = y_levels)
+}
+
+
+#' @title Compute subtitle, caption, and pairwise comparisons for pie/bar charts
+#' @name .pie_bar_subtitle_caption
+#'
+#' @description
+#'
+#' Shared helper for `ggpiestats()` and `ggbarstats()` that runs the
+#' contingency table test, optionally computes a Bayes Factor caption, and
+#' performs pairwise comparisons when applicable.
+#'
+#' @inheritParams ggpiestats
+#'
+#' @return A named list with elements `subtitle`, `caption`, `subtitle_df`,
+#'   `caption_df`, and `mpc_df`.
+#'
+#' @autoglobal
+#' @noRd
+.pie_bar_subtitle_caption <- function(
+  data,
+  x,
+  y,
+  type,
+  paired,
+  bf.message,
+  alternative,
+  conf.level,
+  digits,
+  ratio,
+  sampling.plan,
+  fixed.margin,
+  prior.concentration,
+  x_levels,
+  y_levels,
+  p.adjust.method
+) {
+  .f.args <- list(
+    data = data,
+    x = {{ x }},
+    y = {{ y }},
+    alternative = alternative,
+    conf.level = conf.level,
+    digits = digits,
+    paired = paired,
+    ratio = ratio,
+    sampling.plan = sampling.plan,
+    fixed.margin = fixed.margin,
+    prior.concentration = prior.concentration
+  )
+
+  subtitle_df <- .eval_f(contingency_table, !!!.f.args, type = type)
+  subtitle <- .extract_expression(subtitle_df)
+  caption_df <- NULL
+  caption <- NULL
+
+  if (type != "bayes" && bf.message && isFALSE(paired)) {
+    caption_df <- .eval_f(contingency_table, !!!.f.args, type = "bayes")
+    caption <- .extract_expression(caption_df)
+  }
+
+  mpc_df <- .pairwise_contingency(
+    data,
+    {{ x }},
+    {{ y }},
+    x_levels,
+    y_levels,
+    paired,
+    digits,
+    conf.level,
+    alternative,
+    p.adjust.method
+  )
+
+  list(
+    subtitle = subtitle,
+    caption = caption,
+    subtitle_df = subtitle_df,
+    caption_df = caption_df,
+    mpc_df = mpc_df
+  )
+}
+
+
 #' @title A data frame with descriptive labels
 #' @autoglobal
 #' @noRd

--- a/R/ggpiestats.R
+++ b/R/ggpiestats.R
@@ -148,13 +148,14 @@ ggpiestats <- function(
   # statistical analysis ------------------------------------------
 
   if (results.subtitle) {
-    sc <- .pie_bar_subtitle_caption(
+    stats_output <- .pie_bar_subtitle_caption(
       data,
       {{ x }},
       {{ y }},
       type,
       paired,
       bf.message,
+      caption,
       alternative,
       conf.level,
       digits,
@@ -166,11 +167,11 @@ ggpiestats <- function(
       y_levels,
       p.adjust.method
     )
-    subtitle <- sc$subtitle
-    caption <- sc$caption
-    subtitle_df <- sc$subtitle_df
-    caption_df <- sc$caption_df
-    mpc_df <- sc$mpc_df
+    subtitle <- stats_output$subtitle
+    caption <- stats_output$caption
+    subtitle_df <- stats_output$subtitle_df
+    caption_df <- stats_output$caption_df
+    mpc_df <- stats_output$mpc_df
   }
 
   # plot ------------------------------------------

--- a/R/ggpiestats.R
+++ b/R/ggpiestats.R
@@ -128,7 +128,12 @@ ggpiestats <- function(
   y <- if (!quo_is_null(enquo(y))) ensym(y)
   type <- stats_type_switch(type)
 
-  prep <- .pie_bar_data_prep(data, {{ x }}, {{ y }}, {{ counts }})
+  prep <- .pie_bar_data_prep(
+    data = data,
+    x = {{ x }},
+    y = {{ y }},
+    counts = {{ counts }}
+  )
   data <- prep$data
   test <- prep$test
   x_levels <- prep$x_levels
@@ -149,23 +154,23 @@ ggpiestats <- function(
 
   if (results.subtitle) {
     stats_output <- .pie_bar_subtitle_caption(
-      data,
-      {{ x }},
-      {{ y }},
-      type,
-      paired,
-      bf.message,
-      caption,
-      alternative,
-      conf.level,
-      digits,
-      ratio,
-      sampling.plan,
-      fixed.margin,
-      prior.concentration,
-      x_levels,
-      y_levels,
-      p.adjust.method
+      data = data,
+      x = {{ x }},
+      y = {{ y }},
+      type = type,
+      paired = paired,
+      bf.message = bf.message,
+      caption = caption,
+      alternative = alternative,
+      conf.level = conf.level,
+      digits = digits,
+      ratio = ratio,
+      sampling.plan = sampling.plan,
+      fixed.margin = fixed.margin,
+      prior.concentration = prior.concentration,
+      x_levels = x_levels,
+      y_levels = y_levels,
+      p.adjust.method = p.adjust.method
     )
     subtitle <- stats_output$subtitle
     caption <- stats_output$caption

--- a/R/ggpiestats.R
+++ b/R/ggpiestats.R
@@ -124,36 +124,22 @@ ggpiestats <- function(
 
   # data frame ------------------------------------------
 
-  # ensure the variables work quoted or unquoted
   x <- ensym(x)
   y <- if (!quo_is_null(enquo(y))) ensym(y)
   type <- stats_type_switch(type)
 
-  # one-way or two-way table?
-  test <- ifelse(quo_is_null(enquo(y)), "one.way", "two.way")
+  prep <- .pie_bar_data_prep(data, {{ x }}, {{ y }}, {{ counts }})
+  data <- prep$data
+  test <- prep$test
+  x_levels <- prep$x_levels
+  y_levels <- prep$y_levels
 
-  data %<>%
-    select({{ x }}, {{ y }}, .counts = {{ counts }}) %>%
-    tidyr::drop_na()
-
-  # untable the data frame based on the count for each observation
-  if (".counts" %in% names(data)) {
-    data %<>% tidyr::uncount(weights = .counts)
-  }
-
-  # x and y need to be a factor
-  data %<>% mutate(across(.cols = everything(), .fns = ~ as.factor(.x)))
-  x_levels <- nlevels(pull(data, {{ x }}))
-  y_levels <- ifelse(test == "one.way", 0L, nlevels(pull(data, {{ y }})))
-
-  # one-way table not supported in `BayesFactor` ATM (richarddmorey/BayesFactor#159)
   # nocov start
   if (test == "two.way" && y_levels == 1L) {
     bf.message <- FALSE
   }
   # nocov end
 
-  # faceting is possible only if both vars have more than one level
   facet <- as.logical(y_levels > 1L)
   if ((x_levels == 1L && facet) || type == "bayes") {
     proportion.test <- FALSE
@@ -162,42 +148,17 @@ ggpiestats <- function(
   # statistical analysis ------------------------------------------
 
   if (results.subtitle) {
-    .f.args <- list(
-      data = data,
-      x = {{ x }},
-      y = {{ y }},
-      alternative = alternative,
-      conf.level = conf.level,
-      digits = digits,
-      paired = paired,
-      ratio = ratio,
-      sampling.plan = sampling.plan,
-      fixed.margin = fixed.margin,
-      prior.concentration = prior.concentration
+    sc <- .pie_bar_subtitle_caption(
+      data, {{ x }}, {{ y }}, type, paired, bf.message,
+      alternative, conf.level, digits, ratio,
+      sampling.plan, fixed.margin, prior.concentration,
+      x_levels, y_levels, p.adjust.method
     )
-
-    subtitle_df <- .eval_f(contingency_table, !!!.f.args, type = type)
-    subtitle <- .extract_expression(subtitle_df)
-
-    # Bayes Factor caption
-    if (type != "bayes" && bf.message && isFALSE(paired)) {
-      caption_df <- .eval_f(contingency_table, !!!.f.args, type = "bayes")
-      caption <- .extract_expression(caption_df)
-    }
-
-    # pairwise comparisons
-    mpc_df <- .pairwise_contingency(
-      data,
-      {{ x }},
-      {{ y }},
-      x_levels,
-      y_levels,
-      paired,
-      digits,
-      conf.level,
-      alternative,
-      p.adjust.method
-    )
+    subtitle <- sc$subtitle
+    caption <- sc$caption
+    subtitle_df <- sc$subtitle_df
+    caption_df <- sc$caption_df
+    mpc_df <- sc$mpc_df
   }
 
   # plot ------------------------------------------

--- a/R/ggpiestats.R
+++ b/R/ggpiestats.R
@@ -149,10 +149,22 @@ ggpiestats <- function(
 
   if (results.subtitle) {
     sc <- .pie_bar_subtitle_caption(
-      data, {{ x }}, {{ y }}, type, paired, bf.message,
-      alternative, conf.level, digits, ratio,
-      sampling.plan, fixed.margin, prior.concentration,
-      x_levels, y_levels, p.adjust.method
+      data,
+      {{ x }},
+      {{ y }},
+      type,
+      paired,
+      bf.message,
+      alternative,
+      conf.level,
+      digits,
+      ratio,
+      sampling.plan,
+      fixed.margin,
+      prior.concentration,
+      x_levels,
+      y_levels,
+      p.adjust.method
     )
     subtitle <- sc$subtitle
     caption <- sc$caption

--- a/R/ggwithinstats.R
+++ b/R/ggwithinstats.R
@@ -211,11 +211,16 @@ ggwithinstats <- function(
       .f.args$alternative <- alternative
     }
 
-    sc <- .bw_subtitle_caption(test, type, bf.message, .f.args)
-    subtitle <- sc$subtitle
-    caption <- sc$caption
-    subtitle_df <- sc$subtitle_df
-    caption_df <- sc$caption_df
+    stats_output <- .bw_subtitle_caption(
+      test = test,
+      type = type,
+      bf.message = bf.message,
+      .f.args = .f.args
+    )
+    subtitle <- stats_output$subtitle
+    caption <- stats_output$caption
+    subtitle_df <- stats_output$subtitle_df
+    caption_df <- stats_output$caption_df
   }
 
   # plot -------------------------------------------

--- a/R/globals.R
+++ b/R/globals.R
@@ -3,8 +3,7 @@
 utils::globalVariables(c(
   # <ggwithinstats>
   ".",
-  # <ggbarstats>
-  # <ggpiestats>
+  # <.pie_bar_data_prep>
   ".counts",
   # <ggbarstats>
   # <ggpiestats>


### PR DESCRIPTION
## Summary

Closes #764 (P2: `ggpiestats` and `ggbarstats`).

- Extracts shared data preparation into `.pie_bar_data_prep()`: column selection, NA handling, count untabling, factor conversion, and level computation.
- Extracts shared statistical analysis into `.pie_bar_subtitle_caption()`: contingency table test, Bayes Factor caption, and pairwise comparisons.
- Both helpers are added to `R/ggpiestats-ggbarstats-helpers.R`, following the same pattern used for `ggbetweenstats`/`ggwithinstats` in #1075.
- No test changes — all existing tests pass identically before and after the refactoring.

## Test plan

- [x] `devtools::test(filter = "ggpiestats")` — same results as `main` (FAIL 9 vdiffr / PASS 18)
- [x] `devtools::test(filter = "ggbarstats")` — same results as `main` (FAIL 9 vdiffr / PASS 18)
- [x] Full test suite — same results as `main` (FAIL 57 vdiffr / PASS 135)
- [x] `styler::style_file()` — no formatting changes needed
- [x] `devtools::document()` — clean