### PR TITLE
refactor: extract x-level stabilization into shared helper

### DIFF
--- a/R/ggbarstats.R
+++ b/R/ggbarstats.R
@@ -268,19 +268,7 @@ grouped_ggbarstats <- function(
   plotgrid.args = list(),
   annotation.args = list()
 ) {
-  dots_q <- rlang::enquos(...)
-  x_q <- dots_q[["x"]] %||% dots_q[[1L]]
-  if (!is.null(x_q) && rlang::is_symbol(rlang::quo_get_expr(x_q))) {
-    x_name <- rlang::as_name(rlang::quo_get_expr(x_q))
-    # nocov start
-    x_lvls <- if (is.factor(data[[x_name]])) {
-      levels(data[[x_name]])
-    } else {
-      sort(unique(data[[x_name]]))
-    }
-    # nocov end
-    data[[x_name]] <- factor(data[[x_name]], x_lvls)
-  }
+  data <- .stabilize_x_factor(data, ...)
   .grouped_list(data, {{ grouping.var }}) %>%
     purrr::pmap(.f = ggbarstats, ...) %>%
     combine_plots(plotgrid.args, annotation.args)

--- a/R/ggpiestats.R
+++ b/R/ggpiestats.R
@@ -299,19 +299,7 @@ grouped_ggpiestats <- function(
   plotgrid.args = list(),
   annotation.args = list()
 ) {
-  dots_q <- rlang::enquos(...)
-  x_q <- dots_q[["x"]] %||% dots_q[[1L]]
-  if (!is.null(x_q) && rlang::is_symbol(rlang::quo_get_expr(x_q))) {
-    x_name <- rlang::as_name(rlang::quo_get_expr(x_q))
-    # nocov start
-    x_lvls <- if (is.factor(data[[x_name]])) {
-      levels(data[[x_name]])
-    } else {
-      sort(unique(data[[x_name]]))
-    }
-    # nocov end
-    data[[x_name]] <- factor(data[[x_name]], x_lvls)
-  }
+  data <- .stabilize_x_factor(data, ...)
   .grouped_list(data, {{ grouping.var }}) %>%
     purrr::pmap(.f = ggpiestats, ...) %>%
     combine_plots(plotgrid.args, annotation.args)

--- a/R/utils.R
+++ b/R/utils.R
@@ -94,6 +94,26 @@
 }
 
 
+#' @autoglobal
+#' @noRd
+.stabilize_x_factor <- function(data, ...) {
+  dots_q <- rlang::enquos(...)
+  x_q <- dots_q[["x"]] %||% dots_q[[1L]]
+  if (!is.null(x_q) && rlang::is_symbol(rlang::quo_get_expr(x_q))) {
+    x_name <- rlang::as_name(rlang::quo_get_expr(x_q))
+    # nocov start
+    x_lvls <- if (is.factor(data[[x_name]])) {
+      levels(data[[x_name]])
+    } else {
+      sort(unique(data[[x_name]]))
+    }
+    # nocov end
+    data[[x_name]] <- factor(data[[x_name]], x_lvls)
+  }
+  data
+}
+
+
 #' @noRd
 .eval_f <- function(.f, ...) {
   tryCatch(


### PR DESCRIPTION
## Summary

- Extracts the duplicated x-level stabilization logic from `grouped_ggpiestats()` and `grouped_ggbarstats()` into a shared `.stabilize_x_factor()` helper in `R/utils.R`
- This is **P4** from the refactoring plan in #764
- Both grouped wrappers now delegate to the shared helper, reducing each function to a one-liner before the `.grouped_list()` pipeline

## Test plan

- [x] No new lint warnings (`lintr::lint_package()`)
- [x] No formatting issues (formatted with `air`)
- [x] No new test failures (all failures are pre-existing vdiffr snapshot mismatches on `main`)
- [x] No changes to unit tests

Closes #764 (P4)