### PR TITLE
refactor: extract one-sample stats into shared helper

### DIFF
--- a/R/ggdotplotstats.R
+++ b/R/ggdotplotstats.R
@@ -93,12 +93,6 @@ ggdotplotstats <- function(
   # make sure both quoted and unquoted arguments are allowed
   c(x, y) %<-% c(ensym(x), ensym(y))
   type <- stats_type_switch(type)
-  .f.stats.args <- list(
-    conf.level = conf.level,
-    digits = digits,
-    tr = tr,
-    bf.prior = bf.prior
-  )
 
   data %<>%
     select({{ x }}, {{ y }}) %>%
@@ -131,26 +125,22 @@ ggdotplotstats <- function(
       x = {{ x }},
       test.value = test.value,
       alternative = alternative,
-      effsize.type = effsize.type
+      effsize.type = effsize.type,
+      conf.level = conf.level,
+      digits = digits,
+      tr = tr,
+      bf.prior = bf.prior
     )
 
-    subtitle_df <- .eval_f(
-      one_sample_test,
-      !!!.f.args,
-      !!!.f.stats.args,
-      type = type
+    stats <- .one_sample_subtitle_caption(
+      type = type,
+      bf.message = bf.message,
+      .f.args = .f.args
     )
-    subtitle <- .extract_expression(subtitle_df)
-
-    if (type == "parametric" && bf.message) {
-      caption_df <- .eval_f(
-        one_sample_test,
-        !!!.f.args,
-        !!!.f.stats.args,
-        type = "bayes"
-      )
-      caption <- .extract_expression(caption_df)
-    }
+    subtitle <- stats$subtitle
+    caption <- stats$caption
+    subtitle_df <- stats$subtitle_df
+    caption_df <- stats$caption_df
   }
 
   # plot -----------------------------------

--- a/R/ggdotplotstats.R
+++ b/R/ggdotplotstats.R
@@ -138,7 +138,7 @@ ggdotplotstats <- function(
       .f.args = .f.args
     )
     subtitle <- stats$subtitle
-    caption <- stats$caption
+    caption <- stats$caption %||% caption
     subtitle_df <- stats$subtitle_df
     caption_df <- stats$caption_df
   }

--- a/R/gghistostats-helpers.R
+++ b/R/gghistostats-helpers.R
@@ -1,3 +1,40 @@
+#' @title Compute subtitle and caption for one-sample test plots
+#' @name .one_sample_subtitle_caption
+#'
+#' @description
+#'
+#' Shared helper for `gghistostats()` and `ggdotplotstats()` that runs the
+#' one-sample test and optionally computes a Bayes Factor caption.
+#'
+#' @param type Character: statistical test type (e.g. `"parametric"`).
+#' @param bf.message Logical: include Bayes Factor caption?
+#' @param .f.args A named list of arguments forwarded to
+#'   [statsExpressions::one_sample_test()].
+#'
+#' @return A list with elements `subtitle` and `caption`.
+#'
+#' @autoglobal
+#' @noRd
+.one_sample_subtitle_caption <- function(type, bf.message, .f.args) {
+  subtitle_df <- .eval_f(one_sample_test, !!!.f.args, type = type)
+  subtitle <- .extract_expression(subtitle_df)
+  caption_df <- NULL
+  caption <- NULL
+
+  if (type == "parametric" && bf.message) {
+    caption_df <- .eval_f(one_sample_test, !!!.f.args, type = "bayes")
+    caption <- .extract_expression(caption_df)
+  }
+
+  list(
+    subtitle = subtitle,
+    caption = caption,
+    subtitle_df = subtitle_df,
+    caption_df = caption_df
+  )
+}
+
+
 #' @title Custom function for adding labeled lines for `x`-axis variable.
 #' @name .histo_labeller
 #'

--- a/R/gghistostats.R
+++ b/R/gghistostats.R
@@ -106,15 +106,15 @@ gghistostats <- function(
       bf.prior = bf.prior
     )
 
-    # subtitle with statistical results
-    subtitle_df <- .eval_f(one_sample_test, !!!.f.args, type = type)
-    subtitle <- .extract_expression(subtitle_df)
-
-    # BF message
-    if (type == "parametric" && bf.message) {
-      caption_df <- .eval_f(one_sample_test, !!!.f.args, type = "bayes")
-      caption <- .extract_expression(caption_df)
-    }
+    stats <- .one_sample_subtitle_caption(
+      type = type,
+      bf.message = bf.message,
+      .f.args = .f.args
+    )
+    subtitle <- stats$subtitle
+    caption <- stats$caption
+    subtitle_df <- stats$subtitle_df
+    caption_df <- stats$caption_df
   }
 
   # plot -----------------------------------

--- a/R/gghistostats.R
+++ b/R/gghistostats.R
@@ -112,7 +112,7 @@ gghistostats <- function(
       .f.args = .f.args
     )
     subtitle <- stats$subtitle
-    caption <- stats$caption
+    caption <- stats$caption %||% caption
     subtitle_df <- stats$subtitle_df
     caption_df <- stats$caption_df
   }


### PR DESCRIPTION
## Summary

- Extracts the shared subtitle/caption computation from `gghistostats()` and `ggdotplotstats()` into a new `.one_sample_subtitle_caption()` helper in `gghistostats-helpers.R`
- Follows the same pattern used by `.bw_subtitle_caption()` (for between/within stats) and `.pie_bar_subtitle_caption()` (for pie/bar stats)
- In `ggdotplotstats()`, merges the previously split `.f.args`/`.f.stats.args` into a single `.f.args` list for consistency with `gghistostats()`
- Addresses **P5** from the refactoring audit in #764

## Test plan

- [x] No new lint issues (`lintr::lint()` clean on all changed files)
- [x] No formatting issues (formatted with `air`)
- [x] Full test suite results identical to `main` (FAIL 57 | PASS 135 — all failures are pre-existing vdiffr snapshot mismatches)
- [x] No unit tests were modified