### PR TITLE
refactor: fold stats argument construction into shared helper (#764 P3)

### DIFF
--- a/R/ggbetweenstats-helpers.R
+++ b/R/ggbetweenstats-helpers.R
@@ -3,19 +3,68 @@
 #'
 #' @description
 #'
-#' Shared helper for `ggbetweenstats()` and `ggwithinstats()` that runs the
-#' appropriate statistical test and optionally computes a Bayes Factor caption.
+#' Shared helper for `ggbetweenstats()` and `ggwithinstats()` that builds the
+#' argument list for the statistical test function and optionally computes a
+#' Bayes Factor caption.
 #'
+#' @param data Data frame for the statistical test.
+#' @param x,y Column name symbols for the grouping and response variables.
 #' @param test Character: `"t"` or `"anova"`.
 #' @param type Character: statistical test type (e.g. `"parametric"`).
 #' @param bf.message Logical: include Bayes Factor caption?
-#' @param .f.args A named list of arguments forwarded to the test function.
+#' @param paired Logical: whether the test is paired (within-subjects).
+#' @param var.equal Logical: assume equal variances? Only used for
+#'   between-subjects tests (`NULL` by default, omitted when `NULL`).
+#' @param subject.id Optional symbol for the subject identifier column
+#'   (within-subjects designs only; `NULL` by default, omitted when `NULL`).
+#' @inheritParams ggbetweenstats
 #'
-#' @return A list with elements `subtitle` and `caption`.
+#' @return A list with elements `subtitle`, `caption`, `subtitle_df`, and
+#'   `caption_df`.
 #'
 #' @autoglobal
 #' @noRd
-.bw_subtitle_caption <- function(test, type, bf.message, .f.args) {
+.bw_subtitle_caption <- function(
+  data,
+  x,
+  y,
+  test,
+  type,
+  bf.message,
+  effsize.type,
+  conf.level,
+  digits,
+  tr,
+  bf.prior,
+  nboot,
+  alternative,
+  paired,
+  var.equal = NULL,
+  subject.id = NULL
+) {
+  .f.args <- list(
+    data = data,
+    x = as_string(x),
+    y = as_string(y),
+    effsize.type = effsize.type,
+    conf.level = conf.level,
+    digits = digits,
+    tr = tr,
+    paired = paired,
+    bf.prior = bf.prior,
+    nboot = nboot
+  )
+
+  if (!is.null(var.equal)) {
+    .f.args$var.equal <- var.equal
+  }
+  if (!is.null(subject.id)) {
+    .f.args$subject.id <- subject.id
+  }
+  if (test == "t") {
+    .f.args$alternative <- alternative
+  }
+
   .f <- .f_switch(test)
   subtitle_df <- .eval_f(.f, !!!.f.args, type = type)
   subtitle <- .extract_expression(subtitle_df)

--- a/R/ggbetweenstats.R
+++ b/R/ggbetweenstats.R
@@ -220,29 +220,22 @@ ggbetweenstats <- function(
   test <- ifelse(nlevels(pull(data, {{ x }})) < 3L, "t", "anova")
 
   if (results.subtitle) {
-    .f.args <- list(
-      data = data,
-      x = as_string(x),
-      y = as_string(y),
-      effsize.type = effsize.type,
-      conf.level = conf.level,
-      var.equal = var.equal,
-      digits = digits,
-      tr = tr,
-      paired = FALSE,
-      bf.prior = bf.prior,
-      nboot = nboot
-    )
-
-    if (test == "t") {
-      .f.args$alternative <- alternative
-    }
-
     stats_output <- .bw_subtitle_caption(
+      data = data,
+      x = x,
+      y = y,
       test = test,
       type = type,
       bf.message = bf.message,
-      .f.args = .f.args
+      effsize.type = effsize.type,
+      conf.level = conf.level,
+      digits = digits,
+      tr = tr,
+      bf.prior = bf.prior,
+      nboot = nboot,
+      alternative = alternative,
+      paired = FALSE,
+      var.equal = var.equal
     )
     subtitle <- stats_output$subtitle
     caption <- stats_output$caption

--- a/R/ggwithinstats.R
+++ b/R/ggwithinstats.R
@@ -193,29 +193,22 @@ ggwithinstats <- function(
   test <- ifelse(nlevels(pull(data, {{ x }})) < 3L, "t", "anova")
 
   if (results.subtitle) {
-    .f.args <- list(
+    stats_output <- .bw_subtitle_caption(
       data = stats_data,
-      x = as_string(x),
-      y = as_string(y),
-      subject.id = subject.id,
+      x = x,
+      y = y,
+      test = test,
+      type = type,
+      bf.message = bf.message,
       effsize.type = effsize.type,
       conf.level = conf.level,
       digits = digits,
       tr = tr,
-      paired = TRUE,
       bf.prior = bf.prior,
-      nboot = nboot
-    )
-
-    if (test == "t") {
-      .f.args$alternative <- alternative
-    }
-
-    stats_output <- .bw_subtitle_caption(
-      test = test,
-      type = type,
-      bf.message = bf.message,
-      .f.args = .f.args
+      nboot = nboot,
+      alternative = alternative,
+      paired = TRUE,
+      subject.id = subject.id
     )
     subtitle <- stats_output$subtitle
     caption <- stats_output$caption


### PR DESCRIPTION
## Summary

- Moves `.f.args` list construction and conditional parameter handling (`var.equal`, `subject.id`, `alternative`) into `.bw_subtitle_caption()`, eliminating duplicated argument-building logic from both `ggbetweenstats()` and `ggwithinstats()`
- This is the P3 refactoring item from #764: extracting shared statistical analysis logic between `ggbetweenstats` and `ggwithinstats` (section 2a)
- The helper now accepts individual parameters directly instead of a pre-built `.f.args` list, constructing the argument list internally and handling the between/within differences (`paired`, `var.equal`, `subject.id`) via optional parameters

Closes the P3 item in #764.

## Test plan

- [x] No new lint warnings (`lintr::lint_package()` clean)
- [x] No formatting issues (`air format` applied)
- [x] Unit test results identical to `main` (57 pre-existing snapshot failures, 135 passes — no regressions)
- [x] No unit tests modified