### PR TITLE
ci: test with statsExpressions PR #356

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Remotes:
-    IndrajeetPatil/statsExpressions
+    IndrajeetPatil/statsExpressions@refactor/reduce-codebase-size
 Config/Needs/check: anthonynorth/roxyglobals
 Config/roxyglobals/unique: TRUE
 Config/testthat/edition: 3


### PR DESCRIPTION
## Summary

- Points `Remotes` to `IndrajeetPatil/statsExpressions@refactor/reduce-codebase-size` (PR https://github.com/IndrajeetPatil/statsExpressions/pull/356)
- Goal: verify that the internal refactors in statsExpressions (replacing `tidyr::drop_na()` with `dplyr::filter()`, simplifying NA removal, replacing `.prettyNum()` with `insight::format_value()`, consolidating effect-size dispatch, and parameterizing `tidy_model_expressions()`) don't break any ggstatsplot tests

## Test plan

- [ ] CI passes with the statsExpressions feature branch
- [ ] Revert `Remotes` before merging (or after statsExpressions PR is merged to main)