### PR TITLE
feat: improve SEO, GEO, and agentic discoverability of pkgdown site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -51,6 +51,7 @@ README.html
 ^paper.*$
 ^pkgdown$
 ^revdep$
+^robots\.txt$
 ^tests/manual$
 publication/*
 references.bib

--- a/.github/workflows/seo-files.yaml
+++ b/.github/workflows/seo-files.yaml
@@ -1,0 +1,72 @@
+on:
+  workflow_run:
+    workflows: ["pkgdown"]
+    types: [completed]
+    branches: [main]
+
+name: Deploy SEO and agentic discovery files
+
+jobs:
+  deploy-seo-files:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Create robots.txt
+        run: |
+          cat > robots.txt << 'EOF'
+          User-agent: *
+          Allow: /
+
+          # Explicitly allow AI crawlers for GEO and agentic access
+          User-agent: GPTBot
+          Allow: /
+
+          User-agent: OAI-SearchBot
+          Allow: /
+
+          User-agent: ChatGPT-User
+          Allow: /
+
+          User-agent: ClaudeBot
+          Allow: /
+
+          User-agent: Claude-SearchBot
+          Allow: /
+
+          User-agent: anthropic-ai
+          Allow: /
+
+          User-agent: PerplexityBot
+          Allow: /
+
+          User-agent: Google-Extended
+          Allow: /
+
+          Sitemap: https://www.indrapatil.com/ggstatsplot/sitemap.xml
+          EOF
+
+      - name: Create .well-known/llms.txt
+        run: |
+          mkdir -p .well-known
+          cat > .well-known/llms.txt << 'EOF'
+          # LLM Documentation Index for ggstatsplot
+          # Machine-readable package documentation for AI assistants
+          # See https://llmstxt.org/ for the specification
+
+          /llms.txt: Concise package overview optimised for AI assistants
+          /llms-full.txt: Complete package documentation for AI assistants
+          EOF
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add robots.txt .well-known/
+          git diff --staged --quiet || git commit -m "chore: update SEO and agentic discovery files"
+          git push

--- a/.github/workflows/seo-files.yaml
+++ b/.github/workflows/seo-files.yaml
@@ -59,8 +59,8 @@ jobs:
           # Machine-readable package documentation for AI assistants
           # See https://llmstxt.org/ for the specification
 
-          /llms.txt: Concise package overview optimised for AI assistants
-          /llms-full.txt: Complete package documentation for AI assistants
+          /ggstatsplot/llms.txt: Concise package overview optimised for AI assistants
+          /ggstatsplot/llms-full.txt: Complete package documentation for AI assistants
           EOF
 
       - name: Commit and push

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -58,6 +58,7 @@ template:
     image:
       src: man/figures/card.png
     twitter:
+      creator: "@patilindrajeets"
       card: summary_large_image
 
 reference:

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -11,7 +11,7 @@ template:
   bootstrap: 5
   light-switch: true
   includes:
-    in-header: |
+    in_header: |
       <!-- Google tag (gtag.js) -->
       <script async src="https://www.googletagmanager.com/gtag/js?id=G-3BQ49J7KYH"></script>
       <script>

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -57,9 +57,6 @@ template:
   opengraph:
     image:
       src: man/figures/card.png
-    twitter:
-      creator: "@patilindrajeets"
-      card: summary_large_image
 
 reference:
   - title: Hypothesis about group differences

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -57,6 +57,8 @@ template:
   opengraph:
     image:
       src: man/figures/card.png
+    twitter:
+      card: summary_large_image
 
 reference:
   - title: Hypothesis about group differences

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -10,9 +10,46 @@ authors:
 template:
   bootstrap: 5
   light-switch: true
-  # includes:
-  #   in-header: |
-  #     <script defer data-domain="indrajeetpatil.github.io/ggstatsplot" src="https://plausible.io/js/plausible.js"></script>
+  includes:
+    in-header: |
+      <!-- Google tag (gtag.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-3BQ49J7KYH"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-3BQ49J7KYH');
+      </script>
+      <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareSourceCode",
+        "name": "ggstatsplot",
+        "description": "Extension of ggplot2 that creates graphics with details from statistical tests included in the plots themselves. Supports parametric, nonparametric, robust, and Bayesian versions of t-test/ANOVA, correlation analyses, contingency table analysis, meta-analysis, and regression analyses.",
+        "url": "https://www.indrapatil.com/ggstatsplot/",
+        "codeRepository": "https://github.com/IndrajeetPatil/ggstatsplot",
+        "programmingLanguage": {
+          "@type": "ComputerLanguage",
+          "name": "R"
+        },
+        "license": "https://opensource.org/licenses/MIT",
+        "version": "1.0.0",
+        "author": {
+          "@type": "Person",
+          "name": "Indrajeet Patil",
+          "url": "https://www.indrapatil.com/",
+          "sameAs": "https://orcid.org/0000-0003-1995-6531"
+        },
+        "keywords": ["R", "ggplot2", "statistics", "data visualization", "Bayesian", "frequentist", "nonparametric", "robust statistics", "ANOVA", "correlation"]
+      }
+      </script>
+      <meta name="citation_title" content="ggstatsplot: ggplot2 Based Plots with Statistical Details" />
+      <meta name="citation_author" content="Indrajeet Patil" />
+      <meta name="citation_year" content="2021" />
+      <meta name="citation_doi" content="10.21105/joss.03236" />
+      <meta name="citation_journal_title" content="Journal of Open Source Software" />
+      <link rel="alternate" type="text/plain" href="/ggstatsplot/llms.txt" title="LLM-friendly documentation summary" />
+      <link rel="alternate" type="text/plain" href="/ggstatsplot/llms-full.txt" title="Full LLM documentation" />
   bslib:
     base_font: { google: "Roboto" }
     heading_font: { google: "Roboto" }
@@ -26,7 +63,6 @@ template:
 
 reference:
   - title: Hypothesis about group differences
-    #desc:  Main functions to use from `ggstatsplot`.
     contents:
       - ggbetweenstats
       - ggwithinstats
@@ -34,19 +70,16 @@ reference:
       - ggdotplotstats
 
   - title: Hypothesis about correlation
-    #desc:  Main functions to use from `ggstatsplot`.
     contents:
       - ggscatterstats
       - ggcorrmat
 
   - title: Hypothesis about composition of categorical variables
-    #desc:  Main functions to use from `ggstatsplot`.
     contents:
       - ggpiestats
       - ggbarstats
 
   - title: Hypothesis about regression coefficients
-    #desc:  Main functions to use from `ggstatsplot`.
     contents:
       - ggcoefstats
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,29 @@
+User-agent: *
+Allow: /
+
+# Explicitly allow AI crawlers for GEO and agentic access
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://www.indrapatil.com/ggstatsplot/sitemap.xml


### PR DESCRIPTION
## Summary

- **Google Analytics**: Added GA4 tracking (G-3BQ49J7KYH) via `pkgdown`'s `template.includes.in_header` — fires on every page without a separate template file
- **Schema.org JSON-LD**: Added `SoftwareSourceCode` structured data so search engines and AI systems understand the package's purpose, author, license, and DOI
- **Academic citation meta tags**: Added `citation_title`, `citation_author`, `citation_year`, `citation_doi`, and `citation_journal_title` tags so Google Scholar and similar systems correctly index the package
- **LLM link relations**: Added `<link rel="alternate">` tags pointing to pkgdown's auto-generated `llms.txt` and `llms-full.txt` — signals their existence to crawlers that don't know to look for them
- **`robots.txt`**: New file explicitly allowing all major AI crawlers (GPTBot, ClaudeBot, OAI-SearchBot, PerplexityBot, Google-Extended, etc.) alongside standard search engines
- **`.github/workflows/seo-files.yaml`**: New workflow triggered after `pkgdown` completes that commits `robots.txt` and `.well-known/llms.txt` to `gh-pages`. This is necessary because `JamesIves/github-pages-deploy-action` does a full overwrite of `gh-pages` on each pkgdown build, so any files added manually would be wiped.
- **Removed commented-out Plausible analytics** from `_pkgdown.yml` (replaced by GA)

## What pkgdown already provides (no changes needed)

- `llms.txt` and `llms-full.txt` — auto-generated from package docs
- `sitemap.xml` — auto-generated
- Open Graph + Twitter Card meta tags — configured in `_pkgdown.yml`

## Test plan

- [ ] Merge PR and wait for `pkgdown` workflow to complete
- [ ] Verify `seo-files` workflow runs and succeeds after `pkgdown`
- [ ] Check `https://www.indrapatil.com/ggstatsplot/robots.txt` returns the robots file
- [ ] Check `https://www.indrapatil.com/ggstatsplot/.well-known/llms.txt` returns the index
- [ ] View page source and confirm GA script + JSON-LD appear in `<head>`
- [ ] Validate JSON-LD via Google's Rich Results Test
- [ ] Confirm GA events appear in Google Analytics dashboard