### PR TITLE
Use consolidated R-CMD-check workflow with hard: true

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -1,6 +1,4 @@
 on:
-  push:
-    branches: [main, master]
   pull_request:
     branches: [main, master]
 
@@ -8,6 +6,7 @@ name: R-CMD-check-hard
 
 jobs:
   R-CMD-check-hard:
-    uses: IndrajeetPatil/workflows/.github/workflows/R-CMD-check-hard.yaml@main
+    uses: IndrajeetPatil/workflows/.github/workflows/R-CMD-check.yaml@main
     with:
+      hard: true
       extra-packages: any::vdiffr any::patrick

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,5 +9,3 @@ name: R-CMD-check
 jobs:
   R-CMD-check:
     uses: IndrajeetPatil/workflows/.github/workflows/R-CMD-check.yaml@main
-    with:
-      error-on: 'ifelse(getRversion() > "4.3", "note", "warning")'


### PR DESCRIPTION
## Summary

- Updates `R-CMD-check-hard.yaml` to call `R-CMD-check.yaml@main` with `hard: true` instead of the now-deleted `R-CMD-check-hard.yaml@main`
- Restricts the trigger to **PR only** (removes push-to-main trigger), matching the behaviour of `pkgdown-no-suggests.yaml`

## Dependency

Requires `IndrajeetPatil/workflows#27` to be merged first (so `R-CMD-check.yaml@main` includes the `hard` input).