### PR TITLE
Update package dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,19 +27,19 @@ Imports:
     datawizard (>= 1.3.1),
     dplyr (>= 1.2.1),
     forcats (>= 1.0.1),
-    ggcorrplot (>= 0.1.4.1),
+    ggcorrplot (>= 0.2.0),
     ggplot2 (>= 4.0.3),
     ggrepel (>= 0.9.8),
     ggside (>= 0.4.1),
     ggsignif (>= 0.6.4),
     glue (>= 1.8.1),
-    insight (>= 1.5.0),
+    insight (>= 1.5.2),
     paletteer (>= 1.7.0),
-    parameters (>= 0.28.3),
+    parameters (>= 0.29.2),
     patchwork (>= 1.3.2),
-    performance (>= 0.16.0),
+    performance (>= 0.17.1),
     purrr (>= 1.2.2),
-    rlang (>= 1.2.0),
+    rlang (>= 1.3.0),
     statsExpressions (>= 2.0.0),
     tidyr (>= 1.3.2),
     utils
@@ -68,6 +68,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/Needs/check: anthonynorth/roxyglobals
+Config/roxygen2/version: 8.0.0
 Config/roxyglobals/unique: TRUE
 Config/testthat/edition: 3
 Config/testthat/parallel: true
@@ -76,4 +77,3 @@ Language: en-US
 LazyData: true
 Roxygen: list( markdown = TRUE, roclets = c("collate", "namespace", "rd",
     "pkgapi::api_roclet", "roxyglobals::global_roclet") )
-Config/roxygen2/version: 8.0.0

--- a/codemeta.json
+++ b/codemeta.json
@@ -362,7 +362,7 @@
       "@type": "SoftwareApplication",
       "identifier": "ggcorrplot",
       "name": "ggcorrplot",
-      "version": ">= 0.1.4.1",
+      "version": ">= 0.2.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -440,7 +440,7 @@
       "@type": "SoftwareApplication",
       "identifier": "insight",
       "name": "insight",
-      "version": ">= 1.5.0",
+      "version": ">= 1.5.2",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -466,7 +466,7 @@
       "@type": "SoftwareApplication",
       "identifier": "parameters",
       "name": "parameters",
-      "version": ">= 0.28.3",
+      "version": ">= 0.29.2",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -492,7 +492,7 @@
       "@type": "SoftwareApplication",
       "identifier": "performance",
       "name": "performance",
-      "version": ">= 0.16.0",
+      "version": ">= 0.17.1",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -518,7 +518,7 @@
       "@type": "SoftwareApplication",
       "identifier": "rlang",
       "name": "rlang",
-      "version": ">= 1.2.0",
+      "version": ">= 1.3.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -560,7 +560,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "9833.79KB",
+  "fileSize": "9833.866KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/tests/testthat/test-ggbarstats.R
+++ b/tests/testthat/test-ggbarstats.R
@@ -129,12 +129,12 @@ test_that("changing labels and aesthetics", {
     list(
       epoch = structure(
         c(1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L),
-        .Label = c("Before", "After"),
+        levels = c("Before", "After"),
         class = "factor"
       ),
       mode = structure(
         c(1L, 1L, 2L, 2L, 3L, 3L, 4L, 4L),
-        .Label = c("A", "P", "C", "T"),
+        levels = c("A", "P", "C", "T"),
         class = "factor"
       ),
       counts = c(30916L, 21117L, 7676L, 1962L, 1663L, 462L, 7221L, 197L),

--- a/tests/testthat/test-ggbetweenstats.R
+++ b/tests/testthat/test-ggbetweenstats.R
@@ -109,8 +109,8 @@ test_that("pairwise.alpha controls displayed pairwise comparisons", {
   )
 
   layer_params <- fig$layers[[length(fig$layers)]]$stat_params
-  sec_axis_name <- paste(
-    deparse(fig$scales$get_scales("y")$secondary.axis$name),
+  sec_axis_name <- deparse1(
+    fig$scales$get_scales("y")$secondary.axis$name,
     collapse = " "
   )
 

--- a/tests/testthat/test-ggwithinstats.R
+++ b/tests/testthat/test-ggwithinstats.R
@@ -157,8 +157,8 @@ test_that("pairwise.alpha controls displayed pairwise comparisons", {
   )
 
   layer_params <- fig$layers[[length(fig$layers)]]$stat_params
-  sec_axis_name <- paste(
-    deparse(fig$scales$get_scales("y")$secondary.axis$name),
+  sec_axis_name <- deparse1(
+    fig$scales$get_scales("y")$secondary.axis$name,
     collapse = " "
   )
 


### PR DESCRIPTION
## Summary

- refresh minimum CRAN dependency versions in `DESCRIPTION`
- synchronize the generated dependency metadata in `codemeta.json`
- replace two linted `paste(deparse(...))` test helpers with `deparse1()`
- replace deprecated test factor `.Label` attributes with `levels`
- retain the existing roxygen2 8.0.0 configuration in tidy DESCRIPTION order

## Dependency updates

- `ggcorrplot`: 0.1.4.1 -> 0.2.0
- `insight`: 1.5.0 -> 1.5.2
- `parameters`: 0.28.3 -> 0.29.2
- `performance`: 0.16.0 -> 0.17.1
- `rlang`: 1.2.0 -> 1.3.0

## Impact

The package now declares the current CRAN versions used to regenerate and validate the package metadata. The test helper updates preserve existing behavior while satisfying the current `lintr` ruleset and R 4.7's factor attribute checks.

## Validation

- `R CMD build .`
- `R CMD check --no-manual ggstatsplot_1.0.0.tar.gz` (`Status: OK`)
- direct assertions for both changed secondary-axis label checks
- equivalence check for `.Label` and `levels` factor construction
- `make lint`
- `make hooks`
- `git diff --check`
- GitHub Actions R-devel matrix for the R 4.7 factor attribute check