### PR TITLE
Fix lint workflow and update dependencies

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,3 +9,7 @@ name: R-CMD-check
 jobs:
   R-CMD-check:
     uses: IndrajeetPatil/workflows/.github/workflows/R-CMD-check.yaml@main
+    with:
+      extra-packages: |
+        Deriv@4.2.0
+        RfastOfficial/Rfast

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,5 +11,4 @@ jobs:
     uses: IndrajeetPatil/workflows/.github/workflows/R-CMD-check.yaml@main
     with:
       extra-packages: |
-        Deriv@4.2.0
         RfastOfficial/Rfast

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@ easystats ecosystem (`insight`, `parameters`, `performance`, `datawizard`, and
 `correlation`). Treat `DESCRIPTION` as the source of truth for dependency
 constraints.
 
+The minimum supported R version is 4.5. CI covers R-devel, the current R
+release, and the previous R release; keep README support wording independent of
+specific version numbers.
+
 ## Developer workflow
 
 Use the repository `Makefile` for routine package tasks:
@@ -63,6 +67,13 @@ make update_deps  # Refresh dependency constraints, docs, and codemeta
 `make update_deps` is a maintenance operation that can rewrite dependency
 constraints and generated metadata. Do not use it merely to install the current
 dependency set.
+
+### Versioning and changelog
+
+- Development versions use a fourth-component `.9000` suffix.
+- Keep the version in `DESCRIPTION`, `codemeta.json`, and the first `NEWS.md`
+  heading synchronized.
+- Record dependency, compatibility, and CI maintenance changes in `NEWS.md`.
 
 ## Testing
 
@@ -160,3 +171,6 @@ coverage, documentation and extra checks, formatting, linting, prek hooks,
 pkgdown builds, and deployment tasks. Most jobs call reusable workflows from
 `IndrajeetPatil/workflows`; update the callers rather than copying those
 workflows into this repository.
+
+The shared R CMD check matrix intentionally covers R-devel, release, and
+oldrel. Do not reintroduce `oldrel-2` unless the package support policy changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,8 @@ dependency set.
 - Development versions use a fourth-component `.9000` suffix.
 - Keep the version in `DESCRIPTION`, `codemeta.json`, and the first `NEWS.md`
   heading synchronized.
-- Record dependency, compatibility, and CI maintenance changes in `NEWS.md`.
+- Record user-facing compatibility changes in `NEWS.md`; omit routine
+  dependency updates and internal lint or CI maintenance.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,3 +175,7 @@ workflows into this repository.
 
 The shared R CMD check matrix intentionally covers R-devel, release, and
 oldrel. Do not reintroduce `oldrel-2` unless the package support policy changes.
+
+Open pull requests as ready for review rather than as drafts. Unless explicitly
+requested, do not wait for CI/CD checks to finish after pushing; report that the
+checks were triggered and include the pull request or workflow link.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,6 +68,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/Needs/check: anthonynorth/roxyglobals
+Config/Needs/website: RfastOfficial/Rfast
 Config/roxygen2/version: 8.0.0
 Config/roxyglobals/unique: TRUE
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     datawizard (>= 1.3.1),
     dplyr (>= 1.2.1),
     forcats (>= 1.0.1),
-    ggcorrplot (>= 0.2.0),
+    ggcorrplot (>= 0.3.0),
     ggplot2 (>= 4.0.3),
     ggrepel (>= 0.9.8),
     ggside (>= 0.4.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ggstatsplot
 Title: 'ggplot2' Based Plots with Statistical Details
-Version: 1.0.0
+Version: 1.0.0.9000
 Authors@R:
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = c("cre", "aut", "cph"),
            comment = c(ORCID = "0000-0003-1995-6531"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ URL: https://www.indrapatil.com/ggstatsplot/,
     https://github.com/IndrajeetPatil/ggstatsplot
 BugReports: https://github.com/IndrajeetPatil/ggstatsplot/issues
 Depends:
-    R (>= 4.3.0)
+    R (>= 4.5.0)
 Imports:
     correlation (>= 0.8.8),
     datawizard (>= 1.3.1),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,13 +5,6 @@
 - The minimum supported R version is now 4.5. The project supports R-devel,
   the current R release, and the previous R release.
 
-- Dependency requirements have been refreshed, including `ggcorrplot >= 0.3.0`.
-
-- Internal tests now use dedicated shape expectations to comply with current
-  `{lintr}` rules.
-
-- CI now rebuilds `{Rfast}` against the active `{RcppParallel}` TBB ABI.
-
 # ggstatsplot 1.0.0
 
 ## NEW FEATURES

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# ggstatsplot 1.0.0.9000
+
+## MINOR CHANGES
+
+- The minimum supported R version is now 4.5. The project supports R-devel,
+  the current R release, and the previous R release.
+
+- Dependency requirements have been refreshed, including `ggcorrplot >= 0.3.0`.
+
+- Internal tests now use dedicated shape expectations to comply with current
+  `{lintr}` rules.
+
+- CI now rebuilds `{Rfast}` against the active `{RcppParallel}` TBB ABI.
+
 # ggstatsplot 1.0.0
 
 ## NEW FEATURES

--- a/README.Rmd
+++ b/README.Rmd
@@ -37,6 +37,9 @@ Status | Usage | Miscellaneous
 [![R build status](https://github.com/IndrajeetPatil/ggstatsplot/workflows/R-CMD-check/badge.svg)](https://github.com/IndrajeetPatil/ggstatsplot) | [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/ggstatsplot?color=blue)](https://CRAN.R-project.org/package=ggstatsplot) | [![codecov](https://codecov.io/gh/IndrajeetPatil/ggstatsplot/branch/main/graph/badge.svg?token=ddrxwt0bj8)](https://app.codecov.io/gh/IndrajeetPatil/ggstatsplot)
 [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html) | [![Daily downloads](https://cranlogs.r-pkg.org/badges/last-day/ggstatsplot?color=blue)](https://CRAN.R-project.org/package=ggstatsplot) | [![DOI](https://joss.theoj.org/papers/10.21105/joss.03167/status.svg)](https://doi.org/10.21105/joss.03167)
 
+> [!NOTE]
+> This package supports R-devel, the current R release, and the previous R release.
+
 ## Raison d'être <img src="man/figures/logo.png" alt="ggstatsplot package logo" align="right" width="360" />
 
 > "What is to be sought in designs for the display of information is the clear

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 | [![R build status](https://github.com/IndrajeetPatil/ggstatsplot/workflows/R-CMD-check/badge.svg)](https://github.com/IndrajeetPatil/ggstatsplot) | [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/ggstatsplot?color=blue)](https://CRAN.R-project.org/package=ggstatsplot) | [![codecov](https://codecov.io/gh/IndrajeetPatil/ggstatsplot/branch/main/graph/badge.svg?token=ddrxwt0bj8)](https://app.codecov.io/gh/IndrajeetPatil/ggstatsplot) |
 | [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html) | [![Daily downloads](https://cranlogs.r-pkg.org/badges/last-day/ggstatsplot?color=blue)](https://CRAN.R-project.org/package=ggstatsplot) | [![DOI](https://joss.theoj.org/papers/10.21105/joss.03167/status.svg)](https://doi.org/10.21105/joss.03167) |
 
+> [!NOTE]
+> This package supports R-devel, the current R release, and the previous R release.
+
 ## Raison d’être <img src="man/figures/logo.png" alt="ggstatsplot package logo" align="right" width="360" />
 
 > “What is to be sought in designs for the display of information is the

--- a/codemeta.json
+++ b/codemeta.json
@@ -304,7 +304,7 @@
       "@type": "SoftwareApplication",
       "identifier": "R",
       "name": "R",
-      "version": ">= 4.3.0"
+      "version": ">= 4.5.0"
     },
     "2": {
       "@type": "SoftwareApplication",

--- a/codemeta.json
+++ b/codemeta.json
@@ -362,7 +362,7 @@
       "@type": "SoftwareApplication",
       "identifier": "ggcorrplot",
       "name": "ggcorrplot",
-      "version": ">= 0.2.0",
+      "version": ">= 0.3.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -560,7 +560,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "9833.866KB",
+  "fileSize": "9833.854KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/IndrajeetPatil/ggstatsplot",
   "issueTracker": "https://github.com/IndrajeetPatil/ggstatsplot/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.0.0",
+  "version": "1.0.0.9000",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/tests/testthat/test-ggbarstats.R
+++ b/tests/testthat/test-ggbarstats.R
@@ -220,7 +220,7 @@ test_that("pairwise comparisons data is returned for 3+ groups", {
   set.seed(123)
   stats_data <- extract_stats(ggbarstats(mtcars, cyl, am))
   expect_s3_class(stats_data$pairwise_comparisons_data, "tbl_df")
-  expect_identical(nrow(stats_data$pairwise_comparisons_data), 3L)
+  expect_shape(stats_data$pairwise_comparisons_data, nrow = 3L)
   expect_true(all(
     c("group1", "group2", "p.value") %in%
       names(stats_data$pairwise_comparisons_data)
@@ -232,7 +232,7 @@ test_that("pairwise comparisons data is returned for 3+ groups", {
     ggbarstats(mtcars, cyl, am, p.adjust.method = "bonferroni")
   )
   expect_s3_class(stats_bonf$pairwise_comparisons_data, "tbl_df")
-  expect_identical(nrow(stats_bonf$pairwise_comparisons_data), 3L)
+  expect_shape(stats_bonf$pairwise_comparisons_data, nrow = 3L)
 
   # 2 levels: no pairwise data
   set.seed(123)

--- a/tests/testthat/test-ggpiestats.R
+++ b/tests/testthat/test-ggpiestats.R
@@ -181,7 +181,7 @@ test_that("pairwise comparisons data is returned for 3+ groups", {
   set.seed(123)
   stats_data <- extract_stats(ggpiestats(mtcars, cyl, am))
   expect_s3_class(stats_data$pairwise_comparisons_data, "tbl_df")
-  expect_identical(nrow(stats_data$pairwise_comparisons_data), 3L)
+  expect_shape(stats_data$pairwise_comparisons_data, nrow = 3L)
   expect_true(all(
     c("group1", "group2", "p.value") %in%
       names(stats_data$pairwise_comparisons_data)
@@ -193,7 +193,7 @@ test_that("pairwise comparisons data is returned for 3+ groups", {
     ggpiestats(mtcars, cyl, am, p.adjust.method = "bonferroni")
   )
   expect_s3_class(stats_bonf$pairwise_comparisons_data, "tbl_df")
-  expect_identical(nrow(stats_bonf$pairwise_comparisons_data), 3L)
+  expect_shape(stats_bonf$pairwise_comparisons_data, nrow = 3L)
 
   # 2 levels: no pairwise data
   set.seed(123)

--- a/tests/testthat/test-ggwithinstats.R
+++ b/tests/testthat/test-ggwithinstats.R
@@ -193,7 +193,7 @@ test_that("subject.id keeps partially observed subjects in the plotting data", {
     )
   )$data[[1L]]
 
-  expect_identical(nrow(point_data), 5L)
+  expect_shape(point_data, nrow = 5L)
   expect_length(unique(point_data$group), 3L)
 })
 
@@ -216,7 +216,7 @@ test_that("missing subject.id values are excluded from paired grouping", {
     )
   )$data[[1L]]
 
-  expect_identical(nrow(point_data), 4L)
+  expect_shape(point_data, nrow = 4L)
   expect_false(anyNA(point_data$group))
   expect_setequal(unique(point_data$group), c(1, 2))
 })


### PR DESCRIPTION
## Summary

- replace direct row-count assertions with `testthat::expect_shape()` to satisfy the newly enabled `expect_shape_linter`
- raise the minimum `ggcorrplot` version from 0.2.0 to 0.3.0
- raise the minimum supported R version from 4.3.0 to 4.5.0
- add a future-proof README callout for R-devel, the current R release, and the previous R release
- begin the `1.0.0.9000` development cycle in `DESCRIPTION`, `codemeta.json`, and `NEWS.md`
- record the user-facing R compatibility change in `NEWS.md` and update `AGENTS.md` with versioning, R-support, changelog, and PR-handoff guidance
- rebuild `Rfast` from its official source in CI so it links against the active `RcppParallel`/TBB ABI

## Why

The scheduled lint workflow began failing after the current `lintr` release enabled `expect_shape_linter`; the source commit itself had previously passed. Using the dedicated shape assertion preserves the test intent while complying with the current lint rule.

The supported-version policy now covers R-devel, the current R release, and the previous R release. The reusable workflow no longer runs `oldrel-2` after IndrajeetPatil/workflows#46 was merged, so the R 4.4-only `Deriv 4.2.0` pin has been removed.

The separate `Rfast` source override remains necessary because `RcppParallel 6.2.0` changed the TBB ABI and cached downstream binaries referenced obsolete symbols.

## Validation

- `make update_deps`
- `make lint`
- `make hooks`
- `make check` under R 4.5.0 for package version `1.0.0.9000` (`R CMD check --no-manual`: Status OK)
- pak dependency resolution selects source `Rfast 2.1.5.2`
- `git diff --check`