### PR TITLE
Delegate recoverable error fallbacks to purrr

### DIFF
--- a/R/0-utils.R
+++ b/R/0-utils.R
@@ -170,12 +170,10 @@ utils::globalVariables(".pre")
 
 
 #' @noRd
-.eval_f <- function(.f, ...) {
-  tryCatch(
-    suppressWarnings(suppressMessages(exec(.f, ...))),
-    error = function(e) NULL
-  )
-}
+.eval_f <- purrr::possibly(
+  function(.f, ...) suppressWarnings(suppressMessages(exec(.f, ...))),
+  otherwise = NULL
+)
 
 
 #' @noRd

--- a/R/ggpiestats-ggbarstats-helpers.R
+++ b/R/ggpiestats-ggbarstats-helpers.R
@@ -197,18 +197,15 @@ onesample_data <- function(data, x, y, digits = 2L, ratio = NULL, ...) {
 #' @autoglobal
 #' @noRd
 .chisq_test_safe <- function(data, x, ratio) {
-  tryCatch(
-    suppressWarnings(contingency_table(data, x, ratio = ratio)),
-    error = function(e) {
-      # nocov start
-      tibble(
-        statistic = NA_real_,
-        p.value = NA_real_,
-        df = NA_real_,
-        method = "Chi-squared test for given probabilities"
-      )
-    } # nocov end
-  )
+  purrr::possibly(
+    function(...) suppressWarnings(contingency_table(...)),
+    otherwise = tibble(
+      statistic = NA_real_,
+      p.value = NA_real_,
+      df = NA_real_,
+      method = "Chi-squared test for given probabilities"
+    )
+  )(data, x, ratio = ratio)
 }
 
 
@@ -234,16 +231,16 @@ onesample_data <- function(data, x, y, digits = 2L, ratio = NULL, ...) {
     return(NULL)
   }
 
-  tryCatch(
-    suppressWarnings(pairwise_contingency_table(
-      data = data,
-      x = {{ x }},
-      y = {{ y }},
-      digits = digits,
-      conf.level = conf.level,
-      alternative = alternative,
-      p.adjust.method = p.adjust.method
-    )),
-    error = function(e) NULL
+  purrr::possibly(
+    function(...) suppressWarnings(pairwise_contingency_table(...)),
+    otherwise = NULL
+  )(
+    data = data,
+    x = {{ x }},
+    y = {{ y }},
+    digits = digits,
+    conf.level = conf.level,
+    alternative = alternative,
+    p.adjust.method = p.adjust.method
   )
 }


### PR DESCRIPTION
## Summary

- replace all three repository-owned tryCatch error branches with purrr::possibly
- preserve warning and message suppression plus the existing NULL and typed tibble fallbacks
- keep the existing early guards for unsupported pairwise contingency comparisons

## Maintenance benefit

The package previously owned three copies of the same recoverable-error control flow. purrr is already a required, mature dependency, and possibly is designed to turn errors into caller-selected fallback values. Delegating that policy removes custom branching and leaves no tryCatch implementation in the R sources, reducing production code by five lines without adding a dependency or abstraction.

## Regression evidence

- exact legacy/new comparisons for successful calls, errors, warnings, messages, chi-squared grouped results, typed chi-squared fallbacks, valid pairwise results, and pairwise NULL fallbacks
- focused helper, ggpiestats, and ggbarstats tests with NOT_CRAN=false
- air format . --check
- make lint
- make hooks
- NOT_CRAN=false make check — Status: OK

A NOT_CRAN=true focused vdiffr run produced the same broad pie/bar SVG drift on untouched main under the same local R and graphics stack, so no renderer-specific snapshots were committed.

NEWS.md was not updated because this is a minor internal simplification with no user-facing behavior or dependency compatibility change.