### PR TITLE
Deduplicate plot extraction dispatch

### DIFF
--- a/R/extract-stats.R
+++ b/R/extract-stats.R
@@ -47,11 +47,13 @@
 #'
 #' extract_stats(p2)
 #' @export
-extract_stats <- function(p) {
+extract_stats <- function(p) .map_plots(p, .extract_stats)
+
+.map_plots <- function(p, .f) {
   if (inherits(p, "patchwork")) {
-    purrr::map(as.list(p), .extract_stats)
+    purrr::map(as.list(p), .f)
   } else {
-    .extract_stats(p)
+    .f(p)
   }
 }
 
@@ -77,28 +79,15 @@ extract_stats <- function(p) {
 
 #' @rdname extract_stats
 #' @export
-extract_subtitle <- function(p) {
-  dat <- extract_stats(p)
-  .pluck_expression <- function(x) {
-    purrr::pluck(x, "subtitle_data", "expression", 1L)
-  }
-  if (inherits(dat, "ggstatsplot_stats")) {
-    .pluck_expression(dat)
-  } else {
-    purrr::map(dat, .pluck_expression)
-  }
-}
+extract_subtitle <- function(p) .extract_plot_expression(p, "subtitle_data")
 
 #' @rdname extract_stats
 #' @export
-extract_caption <- function(p) {
-  dat <- extract_stats(p)
-  .pluck_expression <- function(x) {
-    purrr::pluck(x, "caption_data", "expression", 1L)
-  }
-  if (inherits(dat, "ggstatsplot_stats")) {
-    .pluck_expression(dat)
-  } else {
-    purrr::map(dat, .pluck_expression)
-  }
+extract_caption <- function(p) .extract_plot_expression(p, "caption_data")
+
+.extract_plot_expression <- function(p, data) {
+  .map_plots(
+    p,
+    \(x) purrr::pluck(.extract_stats(x), data, "expression", 1L)
+  )
 }


### PR DESCRIPTION
## Summary

- replace the repeated single-plot versus patchwork branching in `extract_stats()`, `extract_subtitle()`, and `extract_caption()` with one shared dispatcher
- use patchwork's established `as.list()` support to enumerate composed plots in component order
- route subtitle and caption extraction through the same per-plot path as statistics extraction

## Maintenance benefit

The package previously owned three copies of the same dispatch policy, and the expression extractors added another intermediate dispatch over `extract_stats()`. Patchwork 1.3.2 is already a required, mature dependency and its `as.list.patchwork()` method exposes component plots directly. Centralizing that capability removes 24 lines, adds 13, and leaves one implementation of the policy without adding or bumping a dependency.

## Regression evidence

- inspected the installed and first-party patchwork 1.3.2 `as.list.patchwork()` implementation
- compared legacy and delegated outputs before editing across single plots, all major plot families, grouped plots, arbitrary and nested patchworks, plots without statistical subtitles, and unsupported objects
- `NOT_CRAN=true Rscript -e 'devtools::test(filter = "extract-stats")'` — 13 passed, 0 failed, 0 skipped
- single, grouped, and nested patchwork extraction smoke checks
- `air format . --check`
- `make lint` — no lints
- `make hooks` — all hooks passed
- `NOT_CRAN=false make check` — `Status: OK`

## Changelog

`NEWS.md` was not updated because this is a minor internal simplification with no user-facing behavior or dependency compatibility change.
