### PR TITLE
Delegate list plumbing to purrr

### DIFF
--- a/R/ggbetweenstats-helpers.R
+++ b/R/ggbetweenstats-helpers.R
@@ -37,7 +37,7 @@
   paired,
   subject.id = NULL
 ) {
-  .f.args <- list(
+  .f.args <- purrr::compact(list(
     data = data,
     x = as_string(x),
     y = as_string(y),
@@ -45,15 +45,10 @@
     digits = digits,
     tr = tr,
     paired = paired,
-    bf.prior = bf.prior
-  )
-
-  if (!is.null(subject.id)) {
-    .f.args$subject.id <- subject.id
-  }
-  if (test == "t") {
-    .f.args$alternative <- alternative
-  }
+    bf.prior = bf.prior,
+    subject.id = subject.id,
+    alternative = if (test == "t") alternative
+  ))
 
   .subtitle_caption(.f_switch(test), .f.args, type, bf.message)
 }
@@ -296,7 +291,7 @@
   # creating a column for group combinations
   mpc_df <- mutate(
     mpc_df,
-    groups = purrr::pmap(.l = list(group1, group2), .f = c)
+    groups = purrr::map2(group1, group2, c)
   )
 
   # total number of group-pair comparisons, before any significance filtering;


### PR DESCRIPTION
## Summary

- use purrr::compact() to declare optional statistical-test arguments once and remove manual list mutation branches
- use purrr::map2() for pairwise group construction instead of routing two vectors through pmap() and an intermediate list

## Maintenance benefit

The package previously owned conditional list assembly for optional arguments and used a generic multi-input mapper for an exactly two-input operation. purrr is already a required, mature dependency, and its purpose-built compact() and map2() APIs express both policies directly. The change removes five production lines without adding or bumping a dependency.

## Regression evidence

- verified current purrr compact() and map2() semantics against first-party documentation
- compared legacy and delegated optional-argument lists across t-test and ANOVA paths, with and without subject IDs
- compared pmap() and map2() outputs for plain, factor, named, recycled, empty, and actual parametric, nonparametric, and robust pairwise-comparison inputs
- air format . --check
- focused between-subjects, within-subjects, and pairwise tests: 18 passed, 0 failed; 11 CRAN-gated visual cases skipped
- non-CRAN focused run reproduced the same 10 local renderer-specific vdiffr failures on untouched origin/main, so no snapshot churn was committed
- make lint: no lints
- make hooks: all hooks passed
- NOT_CRAN=false make check: Status: OK
- git diff --check

## Changelog

NEWS.md was not updated because this is a minor internal simplification with no user-facing behavior or dependency compatibility change.