### PR TITLE
CRAN Release 1.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ggstatsplot
 Title: 'ggplot2' Based Plots with Statistical Details
-Version: 1.1.0.9000
+Version: 1.1.1
 Authors@R:
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = c("cre", "aut", "cph"),
            comment = c(ORCID = "0000-0003-1995-6531"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ggstatsplot 1.1.0.9000
+# ggstatsplot 1.1.1
 
 ## MINOR CHANGES
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/IndrajeetPatil/ggstatsplot",
   "issueTracker": "https://github.com/IndrajeetPatil/ggstatsplot/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.1.0.9000",
+  "version": "1.1.1",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,13 +2,7 @@
 
 0 errors | 0 warnings | 0 notes
 
-- This is a minor release (1.1.0).
-- This is a resubmission. It fixes the URL diagnostics reported by CRAN by
-  using the canonical CRAN package URL in `README.md` and the package website
-  for the historical `{statsExpressions}` NEWS link.
-- This release fixes the CRAN daily-check NOTE about deprecated `.Label` use
-  in a test fixture by replacing it with the supported `levels` argument.
-  See `NEWS.md` for a detailed changelog.
+- This is a patch release (1.1.1). See `NEWS.md` for a detailed changelog.
 
 ## revdepcheck results
 


### PR DESCRIPTION
## Summary

- synchronize `DESCRIPTION`, `NEWS.md`, and `codemeta.json` on version 1.1.1
- prepare the existing user-facing fix for all-negative pairwise significance bracket positioning for CRAN
- refresh `cran-comments.md` for a clean patch release and remove stale 1.1.0 resubmission details

## Validation

- `air format . --check`
- `make lint`
- `make hooks`
- `make check` (0 errors, 0 warnings, 0 notes)
- `git diff --check`